### PR TITLE
Added more option at issue creation process

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: General Question
+    url: https://discord.gg/FdvUEEU864
+    about: Please join our Discord for general inquiries.


### PR DESCRIPTION
Let users, when creating an issue on GitHub, select two more options:
1. Blank issue (no template, option pretty "hidden")
2. Ability to join Discord from right there.