### PR TITLE
Add Ditto as a replacement for the Windows Clipboard History

### DIFF
--- a/src/20H2/AtlasModules/atlas-config.bat
+++ b/src/20H2/AtlasModules/atlas-config.bat
@@ -2394,3 +2394,26 @@ ping -n 1 -4 1.1.1.1 ^|Find "Failulre"|(
 	goto netcheck
 )
 goto :EOF
+
+:dittoPreInstall
+reg query HKCU\Software\Microsoft\Clipboard /v EnableClipboardHistory
+if %ERRORLEVEL% EQU 0 goto :dittoDownloadAndInstall
+if %ERRORLEVEL% EQU 1 goto :dittoChoice
+:dittoChoice
+set /P c="It appears that you have the Microsoft Clipboard History enabled, would you like to disable it before installing Ditto?[Y/N]: "
+if /I "%c%" EQU "Y" goto :cbdhsvcD2
+if /I "%c%" EQU "N" goto :dittoDownloadAndInstall
+:cbdhsvcD2
+for /f %%I in ('reg query "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services" /s /k /f cbdhsvc ^| find /i "cbdhsvc" ') do (
+  reg add "%%I" /v "Start" /t REG_DWORD /d "4" /f
+)
+C:\Windows\AtlasModules\nsudo -U:C -P:E -Wait reg add "HKEY_CURRENT_USER\Software\Microsoft\Clipboard" /v "EnableClipboardHistory" /t REG_DWORD /d "0" /f
+reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\System" /v "AllowClipboardHistory" /t REG_DWORD /d "0" /f
+IF %ERRORLEVEL% EQU 0 echo %date% - %time% Clipboard History Disabled...>> C:\Windows\AtlasModules\logs\userScript.log
+goto dittoDownloadAndInstall
+:dittoDownloadAndInstall
+curl -L --output C:\Windows\AtlasModules\dittoI.exe https://github.com/sabrogden/Ditto/releases/download/3.24.214.0/DittoSetup_64bit_3_24_214_0.exe
+IF %ERRORLEVEL% EQU 0 echo %date% - %time% Ditto is being installed...>> C:\Windows\AtlasModules\logs\userScript.log
+"dittoI.exe"
+echo %date% - %time% Please complete the Ditto installation that will pop up after this message>> C:\Windows\AtlasModules\logs\userScript.log
+goto finishNRB

--- a/src/20H2/Desktop/Atlas/1. Scripts/Clipboard History and Snip & Sketch/Install Ditto.bat
+++ b/src/20H2/Desktop/Atlas/1. Scripts/Clipboard History and Snip & Sketch/Install Ditto.bat
@@ -1,0 +1,2 @@
+@echo off
+C:\Windows\AtlasModules\nsudo -U:T -P:E -UseCurrentConsole -Wait C:\Windows\AtlasModules\atlas-config-beta.bat /ditto


### PR DESCRIPTION
...yep!
There's two problems with this PR however:
1- We are downloading the x64 version of Ditto, so if a x32 user tries to use this, it just won't work. Zusier told me to use x64, but yea, it's definitely something that should be fixed in the future. I was thinking of somehow checking the current architecture, and if it's x32, the script would grab the latest Ditto version for x32 with this script that I found https://gist.github.com/steinwaywhw/a4cd19cda655b8249d908261a62687f8. I don't have enough skills to do this, as this is literally my first time doing something with batch.
2- The first registry query on the ::dittoPreInstall function doesn't work. I think this is a really simple fix, and I did try to search through the Microsoft docs to find what I'm doing wrong, but I still cannot understand. Any help on this would be appreciated :)

PS: I am writing this at 10 AM after going to sleep at 3 AM, and I'm not a native English speaker, so it's possible that some of the stuff I just said are written awfully wrong. Sorry about it :S