### PR TITLE
Add "__COMPAT_LAYER" to disable FSO

### DIFF
--- a/src/20H2/AtlasModules/atlas-config.bat
+++ b/src/20H2/AtlasModules/atlas-config.bat
@@ -1074,6 +1074,7 @@ C:\Windows\AtlasModules\nsudo -U:C -P:E -Wait reg add "HKEY_CURRENT_USER\System\
 C:\Windows\AtlasModules\nsudo -U:C -P:E -Wait reg add "HKEY_CURRENT_USER\System\GameConfigStore" /v "GameDVR_DSEBehavior" /t REG_DWORD /d "2" /f
 reg add "HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\GameDVR" /v "AllowGameDVR" /t REG_DWORD /d "0" /f
 C:\Windows\AtlasModules\nsudo -U:C -P:E -Wait reg add "HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\GameDVR" /v "AppCaptureEnabled" /t REG_DWORD /d "0" /f
+reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /v "__COMPAT_LAYER" /t REG_SZ /v "~ DISABLEDXMAXIMIZEDWINDOWEDMODE" /f
 
 :: Disallow Background Apps
 reg add "HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\AppPrivacy" /v "LetAppsRunInBackground" /t REG_DWORD /d "2" /f

--- a/src/20H2/Desktop/Atlas/3. Configuration/FSO & Gamebar/Disable FSO & Gamebar (default).reg
+++ b/src/20H2/Desktop/Atlas/3. Configuration/FSO & Gamebar/Disable FSO & Gamebar (default).reg
@@ -24,3 +24,6 @@ Windows Registry Editor Version 5.00
 
 [HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\BcastDVRUserService]
 "Start"=dword:00000004
+
+[HKEY_CURRENT_USER\Environment]
+"__COMPAT_LAYER"="~ DISABLEDXMAXIMIZEDWINDOWEDMODE"

--- a/src/20H2/Desktop/Atlas/3. Configuration/FSO & Gamebar/Disable FSO & Gamebar (default).reg
+++ b/src/20H2/Desktop/Atlas/3. Configuration/FSO & Gamebar/Disable FSO & Gamebar (default).reg
@@ -25,5 +25,5 @@ Windows Registry Editor Version 5.00
 [HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\BcastDVRUserService]
 "Start"=dword:00000004
 
-[HKEY_CURRENT_USER\Environment]
+[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Environment]
 "__COMPAT_LAYER"="~ DISABLEDXMAXIMIZEDWINDOWEDMODE"

--- a/src/20H2/Desktop/Atlas/3. Configuration/FSO & Gamebar/Enable FSO & Gamebar.reg
+++ b/src/20H2/Desktop/Atlas/3. Configuration/FSO & Gamebar/Enable FSO & Gamebar.reg
@@ -25,5 +25,5 @@ Windows Registry Editor Version 5.00
 [HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\BcastDVRUserService]
 "Start"=dword:00000003
 
-[HKEY_CURRENT_USER\Environment]
+[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Environment]
 "__COMPAT_LAYER"=-

--- a/src/20H2/Desktop/Atlas/3. Configuration/FSO & Gamebar/Enable FSO & Gamebar.reg
+++ b/src/20H2/Desktop/Atlas/3. Configuration/FSO & Gamebar/Enable FSO & Gamebar.reg
@@ -24,3 +24,6 @@ Windows Registry Editor Version 5.00
 
 [HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\BcastDVRUserService]
 "Start"=dword:00000003
+
+[HKEY_CURRENT_USER\Environment]
+"__COMPAT_LAYER"=-


### PR DESCRIPTION
This adds the `__COMPAT_LAYER` environment variable to set the 'Disable full-screen optimisations' compatibility flag globally on every application, ensuring that full-screen optimisations are disabled.

https://stackoverflow.com/questions/37878185/what-does-compat-layer-actually-do/37881453#37881453