### PR TITLE
Fix links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Whilst keeping our main focus on performance, we're also a great option to reduc
   - [What is the Atlas project?](https://github.com/Atlas-OS/Atlas/wiki/1.-FAQ#11-what-is-the-atlas-project)
   - [How do I install Atlas OS?](https://github.com/Atlas-OS/Atlas/wiki/1.-FAQ#12-how-do-i-install-atlas-os)
   - [What's removed in Atlas OS?](https://github.com/Atlas-OS/Atlas/wiki/1.-FAQ#13-whats-removed-in-atlas-os)
-- <a href="#Windows vs. Atlas">Windows vs. Atlas</a>
+- [Windows vs. Atlas](https://github.com/Atlas-OS/Atlas#windows-vs-atlas)
 - [Post Install](https://github.com/Atlas-OS/Atlas/wiki/3.-Post-Install)
-- [Brand Kit]()
+- [Brand Kit](https://github.com/Atlas-OS/Atlas/tree/main/img)
 
 ## Windows vs. Atlas
 


### PR DESCRIPTION
Hyperlink to [Windows vs. Atlas](https://github.com/Atlas-OS/Atlas#Windows%20vs.%20Atlas) doesn't seem to work.
Resolved by manually navigating to the section and copying the link provided, as seen here:
![image](https://user-images.githubusercontent.com/17802843/193454579-20839880-0600-47eb-b6d4-d0fa1fd60558.png)

Hyperlink to BrandKit seems to be empty, resulting in a link to an invalid URL.
Link appears to forward users to /blob/main, which doesn't exist. However, https://github.com/Atlas-OS/Atlas/commit/ba07ae96372347683adcaa419bbb443715c12851 claims that the "brand kit" was "moved" to /img, which gives me reason to believe that this is the brand kit.
