### PR TITLE
Fix line endings on all batch scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.bat eol=crlf
+*.cmd eol=crlf


### PR DESCRIPTION
Create .gitattributes to make sure that all batch scripts are using CRLF (Windows) line endings. With any other line endings, batch labels and many other things get broken.