### PR TITLE
Improve compatibility with older games

### DIFF
--- a/src/Atlas_20H2.xml
+++ b/src/Atlas_20H2.xml
@@ -399,7 +399,6 @@
 		<c>Microsoft.YourPhone 'Your Phone'</c>
 		<c>Microsoft.ZuneMusic 'Groove Music'</c>
 		<c>Microsoft.ZuneVideo 'Movies &amp; TV'</c>
-		<c>midi 'Microsoft GS Wavetable SW Synth (MIDI)'</c>
 		<c>migwiz 'Easy Transfer'</c>
 		<c>mixedreality 'Windows Mixed Reality'</c>
 		<c>mmga 'MMGA MAPI'</c>


### PR DESCRIPTION
Some older games, for example games from the Gothic series, can't run without that component of windows being present.