### PR TITLE
Remove WMI call and unnecessary math (SvcHostSplitThresholdInKB)

### DIFF
--- a/src/AtlasModules/atlas-config.bat
+++ b/src/AtlasModules/atlas-config.bat
@@ -527,9 +527,9 @@ powercfg /setactive scheme_current
 if %ERRORLEVEL%==0 (echo %date% - %time% Power scheme configured...>> %WinDir%\AtlasModules\logs\install.log
 ) ELSE (echo %date% - %time% Failed to configure power scheme! >> %WinDir%\AtlasModules\logs\install.log)
 
-:: set service split treshold
-for /f "tokens=2 delims==" %%i in ('wmic os get TotalVisibleMemorySize /format:value') do set /a RAM=%%i+102400
-reg add "HKLM\SYSTEM\CurrentControlSet\Control" /v "SvcHostSplitThresholdInKB" /t REG_DWORD /d "%RAM%" /f
+:: set service split threshold
+reg add "HKLM\SYSTEM\CurrentControlSet\Control" /v "SvcHostSplitThresholdInKB" /t REG_DWORD /d "4294967295" /f
+
 if %ERRORLEVEL%==0 (echo %date% - %time% Service split treshold set...>> %WinDir%\AtlasModules\logs\install.log
 ) ELSE (echo %date% - %time% Failed to set service split treshold! >> %WinDir%\AtlasModules\logs\install.log)
 


### PR DESCRIPTION
With the current logic, the threshold will *always* be higher than the installed memory so svchost processes will never be split. This is equivalent to setting the DWORD value to the maximum.