### PR TITLE
fix software install unsuccessful due to nsudo not elevated

### DIFF
--- a/src/AtlasModules/atlas-config.bat
+++ b/src/AtlasModules/atlas-config.bat
@@ -2653,7 +2653,7 @@ echo Installing git...
 :: otherwise it will break the whole script if a warning or error shows up
 cmd /c scoop install git -g
 call %WinDir%\AtlasModules\refreshenv.bat
-echo .
+echo]
 echo Adding extras and games bucket...
 cmd /c scoop bucket add extras
 cmd /c scoop bucket add games
@@ -2669,9 +2669,6 @@ PowerShell -NoProfile -Command "%WinDir%\AtlasModules\install.ps1"
 echo Refreshing environment for Chocolatey...
 call %WinDir%\AtlasModules\refreshenv.bat
 echo]
-echo Installing git...
-cmd /c choco install git
-call %WinDir%\AtlasModules\refreshenv.bat
 echo If this did not install Chocolatey, instead you can try installing via the install guide: https://chocolatey.org/install
 goto finish
 

--- a/src/Desktop/Atlas/1. Install Software/Install.ps1
+++ b/src/Desktop/Atlas/1. Install Software/Install.ps1
@@ -39,7 +39,7 @@ if ($provider -eq "Chocolatey") {
         $ChocoInstalled = $true
     } else {
         Write-Host "Chocolatey not found, installing..."
-        C:\Windows\AtlasModules\NSudo.exe -U:C -P:E -UseCurrentConsole -Wait C:\Windows\AtlasModules\atlas-config.bat /choco
+        & "$PSScriptRoot\Manual\Install $provider.bat"
     }
 } else {
     $ScoopInstalled = $false
@@ -47,7 +47,7 @@ if ($provider -eq "Chocolatey") {
         $ScoopInstalled = $true
     } else {
         Write-Host "Scoop not found, installing..."
-        C:\Windows\AtlasModules\NSudo.exe -U:C -P:E -UseCurrentConsole -Wait C:\Windows\AtlasModules\atlas-config.bat /scoop
+        & "$PSScriptRoot\Manual\Install $provider.bat"
     }
 }
 InstallSoftware


### PR DESCRIPTION
Hi,

This PR include 3x changes:

1. I build an image myself and installed it, but find install software not successful with a prompt from NSudo that it's not elevated. So I change the paramater of NSudo from `-U:C` to `-U:E` which will use elevated user instead of current user.
2. scoop and chocolatey are actually installed via `atlas-config.bat`. So we can remove `src/Desktop/Atlas/1. Install Software/Manual/Install Chocolatey.bat` and `src/Desktop/Atlas/1. Install Software/Manual/Install Scoop.bat` since they are never used.
3. I find git is installed during scoop / choco installation which is introduced in 1f064b96979ed5a65d140dbd096d33fb37836fcc, but it's not a necessary step to install scoop or choco. So I remove it. As I tested it does not break anything.
