### PR TITLE
remove disable of write cache flush which may leads to data loss

### DIFF
--- a/src/AtlasModules/atlas-config.bat
+++ b/src/AtlasModules/atlas-config.bat
@@ -1359,14 +1359,6 @@ reg add "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\kernel" /v "Mitig
 :: https://docs.microsoft.com/en-us/windows/security/threat-protection/device-guard/enable-virtualization-based-protection-of-code-integrity
 reg add "HKLM\SYSTEM\CurrentControlSet\Control\DeviceGuard\Scenarios\HypervisorEnforcedCodeIntegrity" /v "Enabled" /t REG_DWORD /d "0" /f
 
-:: disable write cache buffer on all drives
-for /f "tokens=*" %%i in ('reg query "HKLM\SYSTEM\CurrentControlSet\Enum\SCSI" ^| findstr "HKEY"') do (
-	for /f "tokens=*" %%a in ('reg query "%%i" ^| findstr "HKEY"') do (
-		reg add "%%a\Device Parameters\Disk" /v "CacheIsPowerProtected" /t REG_DWORD /d "1" /f
-		reg add "%%a\Device Parameters\Disk" /v "UserWriteCacheSetting" /t REG_DWORD /d "1" /f	
-	)
-)
-
 :: configure multimedia class scheduler
 reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile" /v "SystemResponsiveness" /t REG_DWORD /d "10" /f
 reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile" /v "NoLazyMode" /t REG_DWORD /d "1" /f


### PR DESCRIPTION
This PR removes unnecessary handling of write cache:
![EuZdN](https://user-images.githubusercontent.com/3861028/212527717-6c29c842-a72b-47ba-9637-840a82f40c5f.png)
The image above is the default setting of write cache. Value of 1 for each registry entry means checked in coresponding checkbox.

- `CacheIsPowerProtected` stands for `Enable write caching on the device`. Checking this box will enable cache on disk (usually DRAM of HDD/SSD not but NAND of SSD or disk of HDD) which enable higher performance.
- `UserWriteCacheSetting` is related to caching mechanism of Windows. With this boxed checked, Windows will automatically flush cached IO to disk, so that even if an application does not flush data to disk itself, Windows could still try to keep data safe with its flush mechanism.

So these lines have two problems:

1. The comment says it's disabling write cache but it's actually enabling write cache.
2. It disables Windows flush mechanism, which will not bring performance benefit (acutually this is introduced long time ago, at least as early as Windows Server 2003) but bring potential risk of data loss.

Thus, I removed these additional handlings, and have these as default from Windows.
