### PR TITLE
re-enable onedrive, which allow user to re-install onedrive if need

### DIFF
--- a/src/AtlasModules/atlas-config.bat
+++ b/src/AtlasModules/atlas-config.bat
@@ -982,8 +982,8 @@ reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /v "Hid
 :: disable website access to language list
 %currentuser% reg add "HKCU\Control Panel\International\User Profile" /v "HttpAcceptLanguageOptOut" /t REG_DWORD /d "1" /f
 
-:: disable onedrive
-reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows\OneDrive" /v "DisableFileSyncNGSC" /t REG_DWORD /d "1" /f
+:: re-enable onedrive if user manually reinstall it
+reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows\OneDrive" /v "DisableFileSyncNGSC" /t REG_DWORD /d "0" /f
 
 :: disable require hello sign-in for microsoft accounts
 reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\PasswordLess\Device" /v "DevicePasswordLessBuildVersion" /t REG_DWORD /d "0" /f


### PR DESCRIPTION
Hi,

OneDrive is already removed via NTLite in `Atlas_20H2.xml` and so on. So these lines to disable OneDrive is actually not necessary.

The original registry change cannot either remove OneDrive or prevent it from installing. But if someone wants to install OneDrive, this will block him from start OneDrive.

So the change here fix the bug that manual OneDrive installation could not run.