### PR TITLE
remove enabling of photo viewer which has already been removed by ntlite

### DIFF
--- a/src/AtlasModules/atlas-config.bat
+++ b/src/AtlasModules/atlas-config.bat
@@ -1428,16 +1428,6 @@ reg add "HKLM\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Explorer\Fol
 reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\FolderDescriptions\{B4BFCC3A-DB2C-424C-B029-7FE99A87C641}\PropertyBag" /v "ThisPCPolicy" /t REG_SZ /d "Hide" /f
 reg add "HKLM\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Explorer\FolderDescriptions\{B4BFCC3A-DB2C-424C-B029-7FE99A87C641}\PropertyBag" /v "ThisPCPolicy" /t REG_SZ /d "Hide" /f
 
-:: enable legacy photo viewer
-for %%i in (tif tiff bmp dib gif jfif jpe jpeg jpg jxr png) do (
-    reg add "HKLM\SOFTWARE\Microsoft\Windows Photo Viewer\Capabilities\FileAssociations" /v ".%%~i" /t REG_SZ /d "PhotoViewer.FileAssoc.Tiff" /f
-)
-
-:: set legacy photo viewer as default
-for %%i in (tif tiff bmp dib gif jfif jpe jpeg jpg jxr png) do (
-    %currentuser% reg add "HKCU\SOFTWARE\Classes\.%%~i" /ve /t REG_SZ /d "PhotoViewer.FileAssoc.Tiff" /f
-)
-
 :: disable gamebar presence writer
 reg add "HKLM\SOFTWARE\Microsoft\WindowsRuntime\ActivatableClassId\Windows.Gaming.GameBar.PresenceServer.Internal.PresenceWriter" /v "ActivationType" /t REG_DWORD /d "0" /f
 


### PR DESCRIPTION
Photo viewer is remove in all 3x ntlite presets, such as https://github.com/Atlas-OS/Atlas/blob/a2daeed429bb75021a169d22bf4a9b0f0aa9eac0/src/Atlas_20H2.xml#L421-L422
Thus enabling it has no effect.

I have this change to remove enabling of photo viewer since removal of photo viewer seems happened first.