### PR TITLE
reserve default beep sound

### DIFF
--- a/src/Atlas.reg
+++ b/src/Atlas.reg
@@ -64,3 +64,16 @@ Windows Registry Editor Version 5.00
 
 [HKEY_CLASSES_ROOT\Microsoft.PowerShellScript.1\Shell\Open\Command]
 @="\"C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe\" -File \"%1\""
+
+; set Windows default beep
+
+[HKEY_CURRENT_USER\AppEvents\Schemes\Apps\.Default\.Default]
+
+[HKEY_CURRENT_USER\AppEvents\Schemes\Apps\.Default\.Default\.Current]
+@="C:\\Windows\\media\\Windows Background.wav"
+
+[HKEY_CURRENT_USER\AppEvents\Schemes\Apps\.Default\.Default\.Default]
+@=hex(2):25,00,53,00,79,00,73,00,74,00,65,00,6d,00,52,00,6f,00,6f,00,74,00,25,\
+  00,5c,00,6d,00,65,00,64,00,69,00,61,00,5c,00,57,00,69,00,6e,00,64,00,6f,00,\
+  77,00,73,00,20,00,42,00,61,00,63,00,6b,00,67,00,72,00,6f,00,75,00,6e,00,64,\
+  00,2e,00,77,00,61,00,76,00,00,00

--- a/src/AtlasModules/atlas-config.bat
+++ b/src/AtlasModules/atlas-config.bat
@@ -1436,10 +1436,6 @@ reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Schedule\Maintenance"
 %currentuser% reg add "HKCU\SOFTWARE\Microsoft\Multimedia\Audio\DeviceCpl" /v "ShowDisconnectedDevices" /t REG_DWORD /d "0" /f
 %currentuser% reg add "HKCU\SOFTWARE\Microsoft\Multimedia\Audio\DeviceCpl" /v "ShowHiddenDevices" /t REG_DWORD /d "0" /f
 
-:: set sound scheme to no sounds
-NSudo.exe -U:C -ShowWindowMode:Hide -Wait %PowerShell% "New-ItemProperty -Path 'HKCU:\AppEvents\Schemes' -Name '(Default)' -Value '.None' -Force | Out-Null"
-NSudo.exe -U:C -ShowWindowMode:Hide -Wait %PowerShell% "Get-ChildItem -Path 'HKCU:\AppEvents\Schemes\Apps' | Get-ChildItem | Get-ChildItem | Where-Object {$_.PSChildName -eq '.Current'} | Set-ItemProperty -Name '(Default)' -Value ''"
-
 :: disable audio excludive mode on all devices
 for /f "delims=" %%a in ('reg query "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\MMDevices\Audio\Capture"') do (
     reg add "%%a\Properties" /v "{b3f8fa53-0004-438e-9003-51a46e139bfc},3" /t REG_DWORD /d "0" /f

--- a/src/Atlas_1803.xml
+++ b/src/Atlas_1803.xml
@@ -598,6 +598,9 @@
 			<Machine enabled="yes">Virtual Box VM</Machine>
 			<Machine enabled="no">VMware VM</Machine>
 		</MachineDrivers>
+		<ProtectedFiles>
+			<File>*Media\Windows Background.wav</File>
+		</ProtectedFiles>
 	</Compatibility>
 	<Features></Features>
 	<Packages></Packages>

--- a/src/Atlas_20H2.xml
+++ b/src/Atlas_20H2.xml
@@ -546,6 +546,9 @@
 			<Machine enabled="yes">Virtual Box VM</Machine>
 			<Machine enabled="yes">VMware VM</Machine>
 		</MachineDrivers>
+		<ProtectedFiles>
+			<File>*Media\Windows Background.wav</File>
+		</ProtectedFiles>
 	</Compatibility>
 	<Features>
 		<Feature name="Language.TextToSpeech~~~en-us~0.0.1.0">false</Feature>

--- a/src/Atlas_22H2.xml
+++ b/src/Atlas_22H2.xml
@@ -547,6 +547,9 @@
 			<Machine enabled="yes">Virtual Box VM</Machine>
 			<Machine enabled="yes">VMware VM</Machine>
 		</MachineDrivers>
+		<ProtectedFiles>
+			<File>*Media\Windows Background.wav</File>
+		</ProtectedFiles>
 	</Compatibility>
 	<Features>
 		<Feature name="Language.TextToSpeech~~~en-us~0.0.1.0">false</Feature>


### PR DESCRIPTION
Among all windows sound files, `Windows Background.wav` is a special one. This is the most common sound we heard, and furthermore, this is the sound as a feedback when we turn the volume up / down so we would know how loud the volume is and whether audio works in the system.
So this PR reserve this little & special file from removal by NTLite and set registry to make it works again.

Another minor change is that, the original sound change is in `atlas-config.bat`, I moved it to `Atlas.reg`. The difference is that `atlas-config.bat` would only affect the change of HKCU for current user, while NTLite will apply for all users.

I also remove the change of sound scheme to `No sounds` since it's no longer `No sounds`. Maybe we need to add a new scheme instead?