### PR TITLE
Simplify atlas-config args

### DIFF
--- a/src/Atlas.bat
+++ b/src/Atlas.bat
@@ -4,7 +4,7 @@ echo Please wait. This may take a moment. DO NOT CLOSE THIS WINDOW!
 
 :start
 set success=
-NSudo.exe -U:T -P:E -Wait %WinDir%\AtlasModules\atlas-config.bat /start
+NSudo.exe -U:T -P:E -Wait %WinDir%\AtlasModules\atlas-config.bat /startup
 
 :: read from success file
 set /p success= < C:\Users\Public\success.txt

--- a/src/AtlasModules/atlas-config.bat
+++ b/src/AtlasModules/atlas-config.bat
@@ -55,6 +55,8 @@ SETLOCAL EnableDelayedExpansion
 :: Append any new labels/scripts here (with a comment)
 :: Anything in "" is a comment
 
+:: It has to be the same as the batch labels here!
+
 for %%a in (
 
 "Post install script"

--- a/src/AtlasModules/atlas-config.bat
+++ b/src/AtlasModules/atlas-config.bat
@@ -52,176 +52,101 @@ if not %ERRORLEVEL%==0 (
 :permSUCCESS
 SETLOCAL EnableDelayedExpansion
 
-:: Startup
-if /i "%~1"=="/start"                                        goto startup
+:: Append any new labels/scripts here
+for %%a in (
+	startup
+	test
+	scoopCache
+	choco
+	altsoftwarechoco
+	altsoftwarescoop
+	scoop
+	aniD
+	aniE
+	depD
+	depE
+	backd
+	backe
+	btd
+	bte
+	cbdhsvcD
+	cbdhsvcE
+	eventlogd
+	scheduled
+	eventloge
+	schedulee
+	firewallD
+	firewallE
+	hddd
+	hdde
+	hyperD
+	hyperE
+	ied
+	wmpd
+	storeD
+	storeE
+	networksharingE
+	notiD
+	notiE
+	sleepD
+	sleepE
+	idled
+	idlee
+	printD
+	printE
+	procexpd
+	procexpe
+	indexD
+	indexE
+	SearchStartDisable
+	enableStartSearch
+	openshellInstall
+	startlayout
+	diagd
+	diage
+	uacD
+	uacE
+	uwp
+	uwpE
+	openshellInstall
+	xboxU
+	vpnD
+	vpnE
+	wifiD
+	wifiE
+	workstationD
+	workstationE
+	displayscalingd
+	dscpauto
+	nvcontainerD
+	nvcontainerE
+	nvcontainerCMD
+	nvcontainerCME
+	NVPstate
+	revertNVPState
+	hdcpD
+	hdcpE
+	staticip
+	netAtlasDefault
+	netWinDefault
+	safee
+	safec
+	safen
+	safe
+	vcreR
+) do (if "%~1"=="/%%a" (goto %%a))
+
+:: If the first argument does not match any known scripts, fail
+goto argumentFAIL
 
 :: will loop update check if debugging
-:: Notifications
-if /i "%~1"=="/dn"                                           goto notiD
-if /i "%~1"=="/en"                                           goto notiE
-
-:: Animations
-if /i "%~1"=="/ad"                                           goto aniD
-if /i "%~1"=="/ae"                                           goto aniE
-
-:: Search Indexing
-if /i "%~1"=="/di"                                           goto indexD
-if /i "%~1"=="/ei"                                           goto indexE
-
-:: Wi-Fi
-if /i "%~1"=="/dw"                                           goto wifiD
-if /i "%~1"=="/ew"                                           goto wifiE
-
-:: Hyper-V
-if /i "%~1"=="/dhyper"                                       goto hyperD
-if /i "%~1"=="/ehyper"                                       goto hyperE
-
-:: Microsoft Store
-if /i "%~1"=="/ds"                                           goto storeD
-if /i "%~1"=="/es"                                           goto storeE
-
-:: Background Apps
-if /i "%~1"=="/backd"                                        goto backD
-if /i "%~1"=="/backe"                                        goto backE
-
-:: Bluetooth
-if /i "%~1"=="/btd"                                          goto btD
-if /i "%~1"=="/bte"                                          goto btE
-
-:: HDD Prefetching
-if /i "%~1"=="/hddd"                                         goto hddD
-if /i "%~1"=="/hdde"                                         goto hddE
-
-:: DEP (nx)
-if /i "%~1"=="/depE"                                         goto depE
-if /i "%~1"=="/depD"                                         goto depD
-
-:: Start Menu
-if /i "%~1"=="/ssD"                                          goto SearchStart
-if /i "%~1"=="/ssE"                                          goto enableStart
-if /i "%~1"=="/openshell"                                    goto openshellInstall
-
-:: Remove UWP
-if /i "%~1"=="/uwp"                                          goto uwp
-if /i "%~1"=="/uwpE"                                         goto uwpE
-if /i "%~1"=="/mite"                                         goto mitE
-
-:: Remove Start Menu layout (allow tiles in Start Menu)
-if /i "%~1"=="/stico"                                        goto startlayout
-
-:: Sleep States
-if /i "%~1"=="/sleepD"                                       goto sleepD
-if /i "%~1"=="/sleepE"                                       goto sleepE
-
-:: CPU Idle
-if /i "%~1"=="/idled"                                        goto idleD
-if /i "%~1"=="/idlee"                                        goto idleE
-
-:: Process Explorer
-if /i "%~1"=="/procexpd"                                     goto procexpD
-if /i "%~1"=="/procexpe"                                     goto procexpE
-
-:: Xbox
-if /i "%~1"=="/xboxU"                                        goto xboxU
-
-:: Reinstall VC++ Redistributables
-if /i "%~1"=="/vcreR"                                        goto vcreR
-
-:: User Account Control
-if /i "%~1"=="/uacD"                                         goto uacD
-if /i "%~1"=="/uacE"                                         goto uacE
-if /i "%~1"=="/uacSettings"                                  goto uacSettings
-
-:: Workstation Service (SMB)
-if /i "%~1"=="/workD"                                        goto workstationD
-if /i "%~1"=="/workE"                                        goto workstationE
-
-:: Windows Firewall
-if /i "%~1"=="/firewallD"                                    goto firewallD
-if /i "%~1"=="/firewallE"                                    goto firewallE
-
-:: Printing
-if /i "%~1"=="/printD"                                       goto printD
-if /i "%~1"=="/printE"                                       goto printE
-
-:: Network
-if /i "%~1"=="/netWinDefault"                                goto netWinDefault
-if /i "%~1"=="/netAtlasDefault"                              goto netAtlasDefault
-
-:: Clipboard History Service (also required for Snip and Sketch to copy correctly)
-if /i "%~1"=="/cbdhsvcD"                                     goto cbdhsvcD
-if /i "%~1"=="/cbdhsvcE"                                     goto cbdhsvcE
-
-:: VPN
-if /i "%~1"=="/vpnD"                                         goto vpnD
-if /i "%~1"=="/vpnE"                                         goto vpnE
-
-:: Scoop and Chocolatey
-if /i "%~1"=="/scoop"                                        goto scoop
-if /i "%~1"=="/choco"                                        goto choco
-if /i "%~1"=="/altsoftwarescoop"                             goto altSoftwarescoop
-if /i "%~1"=="/altsoftwarechoco"                             goto altSoftwarechoco
-if /i "%~1"=="/removescoopcache"                             goto scoopCache
-
-:: NVIDIA P-State 0
-if /i "%~1"=="/nvpstateD"                                    goto NVPstate
-if /i "%~1"=="/nvpstateE"                                    goto revertNVPState
-
-:: HDCP
-if /i "%~1"=="/hdcpD"                                        goto hdcpD
-if /i "%~1"=="/hdcpE"                                        goto hdcpE
-
-:: DSCP
-if /i "%~1"=="/dscpauto"                                     goto DSCPauto
-
-:: Display Scaling
-if /i "%~1"=="/displayscalingd"                              goto displayScalingD
-
-:: Static IP
-if /i "%~1"=="/staticip"                                     goto staticIP
-
-:: Windows Media Player
-if /i "%~1"=="/wmpd"                                         goto wmpD
-
-:: Internet Explorer
-if /i "%~1"=="/ied"                                          goto ieD
-
-:: Task Scheduler
-if /i "%~1"=="/scheduled"                                    goto scheduleD
-if /i "%~1"=="/schedulee"                                    goto scheduleE
-
-:: Event Log
-if /i "%~1"=="/eventlogd"                                    goto eventlogD
-if /i "%~1"=="/eventloge"                                    goto eventlogE
-
-:: NVIDIA Display Container LS - he3als
-if /i "%~1"=="/nvcontainerD"                                 goto nvcontainerD
-if /i "%~1"=="/nvcontainerE"                                 goto nvcontainerE
-if /i "%~1"=="/nvcontainerCMD"                               goto nvcontainerCMD
-if /i "%~1"=="/nvcontainerCME"                               goto nvcontainerCME
-
-:: Network Sharing
-if /i "%~1"=="/networksharingE"                              goto networksharingE
-
-:: Diagnostics
-if /i "%~1"=="/diagd"                                        goto diagD
-if /i "%~1"=="/diage"                                        goto diagE
-
-:: Safe Mode
-if /i "%~1"=="/safee"                                        goto safeE
-if /i "%~1"=="/safec"                                        goto safeC
-if /i "%~1"=="/safen"                                        goto safeN
-if /i "%~1"=="/safe"                                         goto safe
-
-:: debugging purposes only
-if /i "%~1"=="/test"                                         goto TestPrompt
-
 :argumentFAIL
-echo atlas-config had no arguements passed to it, either you are launching atlas-config directly or the "%~nx0" script is broken.
+echo atlas-config had no arguements or invalid arguments passed to it.
+echo Either you are launching atlas-config directly or the "%~nx0" script is broken.
 echo Please report this to the Atlas Discord server or Github.
 pause & exit
 
-:TestPrompt
+:Test
 set /p c="Test with echo on?"
 if %c% equ Y echo on
 set /p argPrompt="Which script would you like to test? E.g. (:testScript)"
@@ -1918,7 +1843,7 @@ bcdedit /set nx AlwaysOff
 if %ERRORLEVEL%==0 echo %date% - %time% DEP disabled...>> %WinDir%\AtlasModules\logs\userScript.log
 goto finish
 
-:SearchStart
+:SearchStartDisable
 IF EXIST "C:\Program Files\Open-Shell" goto existS
 IF EXIST "C:\Program Files (x86)\StartIsBack" goto existS
 echo It seems Open-Shell nor StartIsBack are installed. It is HIGHLY recommended to install one of these before running this due to the Start Menu being removed.
@@ -1957,7 +1882,7 @@ NSudo.exe -U:C explorer.exe
 if %ERRORLEVEL%==0 echo %date% - %time% Search and Start Menu disabled...>> %WinDir%\AtlasModules\logs\userScript.log
 goto finish
 
-:enableStart
+:enableStartSearch
 :: rename start menu
 chdir /d %WinDir%\SystemApps\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy
 ren StartMenuExperienceHost.old StartMenuExperienceHost.exe

--- a/src/AtlasModules/atlas-config.bat
+++ b/src/AtlasModules/atlas-config.bat
@@ -52,99 +52,188 @@ if not %ERRORLEVEL%==0 (
 :permSUCCESS
 SETLOCAL EnableDelayedExpansion
 
-:: Append any new labels/scripts here
+:: Append any new labels/scripts here (with a comment)
+:: Anything in "" is a comment
+
 for %%a in (
-	startup
-	test
-	scoopCache
-	choco
-	altsoftwarechoco
-	altsoftwarescoop
-	scoop
-	aniD
-	aniE
-	depD
-	depE
-	backd
-	backe
-	btd
-	bte
-	cbdhsvcD
-	cbdhsvcE
-	eventlogd
-	scheduled
-	eventloge
-	schedulee
-	firewallD
-	firewallE
-	hddd
-	hdde
-	hyperD
-	hyperE
-	ied
-	wmpd
-	storeD
-	storeE
-	networksharingE
-	notiD
-	notiE
-	sleepD
-	sleepE
-	idled
-	idlee
-	printD
-	printE
-	procexpd
-	procexpe
-	indexD
-	indexE
-	SearchStartDisable
-	enableStartSearch
-	openshellInstall
-	startlayout
-	diagd
-	diage
-	uacD
-	uacE
-	uwp
-	uwpE
-	openshellInstall
-	xboxU
-	vpnD
-	vpnE
-	wifiD
-	wifiE
-	workstationD
-	workstationE
-	displayscalingd
-	dscpauto
-	nvcontainerD
-	nvcontainerE
-	nvcontainerCMD
-	nvcontainerCME
-	NVPstate
-	revertNVPState
-	hdcpD
-	hdcpE
-	staticip
-	netAtlasDefault
-	netWinDefault
-	safee
-	safec
-	safen
-	safe
-	vcreR
+
+"Post install script"
+startup
+
+"Test prompt"
+test
+
+"Chocolatey scripts"
+choco
+altsoftwarechoco
+
+"Scoop scripts"
+scoop
+altsoftwarescoop
+scoopCache
+
+"Toggle DWM animations"
+aniD
+aniE
+
+"Toggle Data Execution Prevention (anti-cheat compatibility)"
+depD
+depE
+
+"Toggle background apps"
+backd
+backe
+
+"Toggle Bluetooth services"
+btd
+bte
+
+"Toggle clipboard service (also required for Snip & Sketch)"
+cbdhsvcD
+cbdhsvcE
+
+"Toggle Event Log related components"
+eventloge
+eventlogd
+
+"Toggle Task Scheduler related components"
+schedulee
+scheduled
+
+"Toggle Windows Firewall"
+firewallD
+firewallE
+
+"Toggle HDD performance related features/services"
+hddd
+hdde
+
+"Hyper-V toggle"
+hyperD
+hyperE
+
+"Disable Internet Explorer"
+ied
+
+"Disable Windows Media Player"
+wmpd
+
+"Toggle Microsoft Store"
+storeD
+storeE
+
+"Enable network sharing"
+networksharingE
+
+"Toggle notifications"
+notiD
+notiE
+
+"Toggle sleep states in power plan"
+sleepD
+sleepE
+
+"Toggle CPU idle states in power plan"
+idled
+idlee
+
+"Printing services toggle"
+printD
+printE
+
+"Replace Task Manager with Process Explorer"
+procexpd
+procexpe
+
+"Indexing toggles"
+indexD
+indexE
+
+"Toggle search and start menu services"
+SearchStartDisable
+enableStartSearch
+
+"Unlock start menu layout"
+startlayout
+
+"Diagnostics services toggle"
+diagd
+diage
+
+"Disable/enable UAC"
+uacD
+uacE
+
+"Toggle UWP services"
+uwp
+uwpE
+
+"Install Open Shell (required for disabling search/start menu)"
+openshellInstall
+
+"Uninstall XBOX apps"
+xboxU
+
+"VPN-related services toggle"
+vpnD
+vpnE
+
+"Wi-Fi services toggle"
+wifiD
+wifiE
+
+"Workstation service toggle"
+workstationD
+workstationE
+
+"Disable display scaling (lower latency?)"
+displayscalingd
+
+"Select exe to set DSCP values to"
+dscpauto
+
+"NVIDIA Display Container LS service toggle"
+nvcontainerD
+nvcontainerE
+
+"Context menu for NVIDIA Display Container LS service"
+nvcontainerCMD
+nvcontainerCME
+
+"Force P-State 0 on NVIDIA cards"
+NVPstate
+revertNVPState
+
+"Disable HDCP (High-bandwidth Digital Content Protection)"
+hdcpD
+hdcpE
+
+"Automatic static IP"
+staticip
+
+"Network settings"
+netAtlasDefault
+netWinDefault
+
+"Safe mode scripts"
+safee
+safec
+safen
+safe
+
+"Visual C++ Redistributables AIO Pack"
+vcreR
+
 ) do (if "%~1"=="/%%a" (goto %%a))
 
 :: If the first argument does not match any known scripts, fail
 goto argumentFAIL
 
-:: will loop update check if debugging
 :argumentFAIL
 echo atlas-config had no arguements or invalid arguments passed to it.
 echo Either you are launching atlas-config directly or the "%~nx0" script is broken.
 echo Please report this to the Atlas Discord server or Github.
-pause & exit
+pause & exit /b 1
 
 :Test
 set /p c="Test with echo on?"
@@ -2903,10 +2992,10 @@ exit /b
 
 :permFAIL
 	echo Permission grants failed. Please try again by launching the script through the respected scripts, which will give it the correct permissions.
-	pause & exit
+	pause & exit /b 1
 :finish
 	echo Finished, please reboot for changes to apply.
-	pause & exit
+	pause & exit /b 0
 :finishNRB
 	echo Finished, changes have been applied.
-	pause & exit
+	pause & exit /b 0

--- a/src/Desktop/Atlas/1. Install Software/Cleanup Scoop Cache (after installing any software via Scoop).bat
+++ b/src/Desktop/Atlas/1. Install Software/Cleanup Scoop Cache (after installing any software via Scoop).bat
@@ -1,2 +1,2 @@
 @echo off
-NSudo.exe -U:C -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /removescoopcache
+NSudo.exe -U:C -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /scoopCache

--- a/src/Desktop/Atlas/3. Configuration/Animations/Disable Animations (default).bat
+++ b/src/Desktop/Atlas/3. Configuration/Animations/Disable Animations (default).bat
@@ -1,2 +1,2 @@
 @echo off
-NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /ad
+NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /aniD

--- a/src/Desktop/Atlas/3. Configuration/Animations/Enable Animations.bat
+++ b/src/Desktop/Atlas/3. Configuration/Animations/Enable Animations.bat
@@ -1,2 +1,2 @@
 @echo off
-NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /ae
+NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /aniE

--- a/src/Desktop/Atlas/3. Configuration/Background Apps/Disable Background Apps (default).bat
+++ b/src/Desktop/Atlas/3. Configuration/Background Apps/Disable Background Apps (default).bat
@@ -1,2 +1,2 @@
 @echo off
-NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /backd
+NSudo.exe -U:T -P:E -UseCurrentConsole -Wait "C:\Users\he3als\Documents\GitHub\Atlas\src\AtlasModules\atlas-config.bat" /backdd

--- a/src/Desktop/Atlas/3. Configuration/Background Apps/Disable Background Apps (default).bat
+++ b/src/Desktop/Atlas/3. Configuration/Background Apps/Disable Background Apps (default).bat
@@ -1,2 +1,2 @@
 @echo off
-NSudo.exe -U:T -P:E -UseCurrentConsole -Wait "C:\Users\he3als\Documents\GitHub\Atlas\src\AtlasModules\atlas-config.bat" /backdd
+NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /backd

--- a/src/Desktop/Atlas/3. Configuration/Hyper-V and VBS/Disable Hyper-V and VBS (default).bat
+++ b/src/Desktop/Atlas/3. Configuration/Hyper-V and VBS/Disable Hyper-V and VBS (default).bat
@@ -1,2 +1,2 @@
 @echo off
-NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /dhyper
+NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /hyperD

--- a/src/Desktop/Atlas/3. Configuration/Hyper-V and VBS/Enable Hyper-V and VBS.bat
+++ b/src/Desktop/Atlas/3. Configuration/Hyper-V and VBS/Enable Hyper-V and VBS.bat
@@ -1,2 +1,2 @@
 @echo off
-NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /ehyper
+NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /hyperE

--- a/src/Desktop/Atlas/3. Configuration/Microsoft Store/Disable Microsoft Store.bat
+++ b/src/Desktop/Atlas/3. Configuration/Microsoft Store/Disable Microsoft Store.bat
@@ -1,2 +1,2 @@
 @echo off
-NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /ds
+NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /storeD

--- a/src/Desktop/Atlas/3. Configuration/Microsoft Store/Enable Microsoft Store (default).bat
+++ b/src/Desktop/Atlas/3. Configuration/Microsoft Store/Enable Microsoft Store (default).bat
@@ -1,2 +1,2 @@
 @echo off
-NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /es
+NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /storeE

--- a/src/Desktop/Atlas/3. Configuration/Notifications/Disable Notifications (default).bat
+++ b/src/Desktop/Atlas/3. Configuration/Notifications/Disable Notifications (default).bat
@@ -1,2 +1,2 @@
 @echo off
-NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /dn
+NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /notiD

--- a/src/Desktop/Atlas/3. Configuration/Notifications/Enable Notifications.bat
+++ b/src/Desktop/Atlas/3. Configuration/Notifications/Enable Notifications.bat
@@ -1,2 +1,2 @@
 @echo off
-NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /en
+NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /notiE

--- a/src/Desktop/Atlas/3. Configuration/Search Indexing/Disable Search Indexing (default).bat
+++ b/src/Desktop/Atlas/3. Configuration/Search Indexing/Disable Search Indexing (default).bat
@@ -1,2 +1,2 @@
 @echo off
-NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /di
+NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /indexD

--- a/src/Desktop/Atlas/3. Configuration/Search Indexing/Enable Search Indexing.bat
+++ b/src/Desktop/Atlas/3. Configuration/Search Indexing/Enable Search Indexing.bat
@@ -1,2 +1,2 @@
 @echo off
-NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /ei
+NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /indexE

--- a/src/Desktop/Atlas/3. Configuration/Start Menu/Disable Start Menu and Search.bat
+++ b/src/Desktop/Atlas/3. Configuration/Start Menu/Disable Start Menu and Search.bat
@@ -1,2 +1,2 @@
 @echo off
-NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /ssD
+NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /SearchStartDisable

--- a/src/Desktop/Atlas/3. Configuration/Start Menu/Enable Start Menu and Search.bat
+++ b/src/Desktop/Atlas/3. Configuration/Start Menu/Enable Start Menu and Search.bat
@@ -1,2 +1,2 @@
 @echo off
-NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /ssE
+NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /enableStartSearch

--- a/src/Desktop/Atlas/3. Configuration/Start Menu/Install Open-Shell (run first).bat
+++ b/src/Desktop/Atlas/3. Configuration/Start Menu/Install Open-Shell (run first).bat
@@ -1,2 +1,2 @@
 @echo off
-NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /openshell
+NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /openshellInstall

--- a/src/Desktop/Atlas/3. Configuration/Start Menu/Unlock Start Menu Tiles.bat
+++ b/src/Desktop/Atlas/3. Configuration/Start Menu/Unlock Start Menu Tiles.bat
@@ -1,2 +1,2 @@
 @echo off
-NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /stico
+NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /startlayout

--- a/src/Desktop/Atlas/3. Configuration/UWP/Install Open-Shell (run first).bat
+++ b/src/Desktop/Atlas/3. Configuration/UWP/Install Open-Shell (run first).bat
@@ -1,2 +1,2 @@
 @echo off
-NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /openshell
+NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /openshellInstall

--- a/src/Desktop/Atlas/3. Configuration/Wi-Fi/Disable Wi-Fi.bat
+++ b/src/Desktop/Atlas/3. Configuration/Wi-Fi/Disable Wi-Fi.bat
@@ -1,2 +1,2 @@
 @echo off
-NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /dw
+NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /wifiD

--- a/src/Desktop/Atlas/3. Configuration/Wi-Fi/Enable Wi-Fi (default).bat
+++ b/src/Desktop/Atlas/3. Configuration/Wi-Fi/Enable Wi-Fi (default).bat
@@ -1,2 +1,2 @@
 @echo off
-NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /ew
+NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /wifiE

--- a/src/Desktop/Atlas/3. Configuration/Workstation (SMB)/Disable Lanman Workstation (default).bat
+++ b/src/Desktop/Atlas/3. Configuration/Workstation (SMB)/Disable Lanman Workstation (default).bat
@@ -1,2 +1,2 @@
 @echo off
-NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /workD
+NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /workstationD

--- a/src/Desktop/Atlas/3. Configuration/Workstation (SMB)/Enable Lanman Workstation.bat
+++ b/src/Desktop/Atlas/3. Configuration/Workstation (SMB)/Enable Lanman Workstation.bat
@@ -1,2 +1,2 @@
 @echo off
-NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /workE
+NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /workstationE

--- a/src/Desktop/Atlas/4. Advanced Configuration/NVIDIA/Force P-State 0/NVIDIA Force P-State 0.bat
+++ b/src/Desktop/Atlas/4. Advanced Configuration/NVIDIA/Force P-State 0/NVIDIA Force P-State 0.bat
@@ -1,2 +1,2 @@
 @echo off
-NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /nvpstateD
+NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /NVPstate

--- a/src/Desktop/Atlas/4. Advanced Configuration/NVIDIA/Force P-State 0/Revert NVIDIA Force P-State 0.bat
+++ b/src/Desktop/Atlas/4. Advanced Configuration/NVIDIA/Force P-State 0/Revert NVIDIA Force P-State 0.bat
@@ -1,2 +1,2 @@
 @echo off
-NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /nvpstateE
+NSudo.exe -U:T -P:E -UseCurrentConsole -Wait %WinDir%\AtlasModules\atlas-config.bat /revertNVPState


### PR DESCRIPTION
Makes them easier to add to and read. Also makes the scripts have the same argument as the labels, so it is more simple.