### PR TITLE
remove unnecessary start and stop of ntp service

### DIFF
--- a/src/AtlasModules/atlas-config.bat
+++ b/src/AtlasModules/atlas-config.bat
@@ -279,15 +279,10 @@ if %ERRORLEVEL%==0 (echo %date% - %time% Visual C++ Runtimes installed...>> %log
 
 :: change ntp server from windows server to pool.ntp.org
 w32tm /config /syncfromflags:manual /manualpeerlist:"0.pool.ntp.org 1.pool.ntp.org 2.pool.ntp.org 3.pool.ntp.org"
-sc queryex "w32time" | find "STATE" | find /v "RUNNING" || (
-    net stop w32time
-    net start w32time
-) > nul 2>nul
 
 :: resync time to pool.ntp.org
 w32tm /config /update
 w32tm /resync
-sc stop W32Time
 %setSvc% W32Time 4
 if %ERRORLEVEL%==0 (echo %date% - %time% NTP server set...>> %log%
 ) ELSE (echo %date% - %time% Failed to set NTP server! >> %log%)


### PR DESCRIPTION
This PR include 2x cleanup:

1. modification to ntp server don't require service restart, as `w32tm /config /update` in next line will do the update. I captured ntp frames via Wireshark could prove so,
2. since W32Time is disabled and we'll restart system at the end, we also don't need to stop it in script.