### PR TITLE
start ntp before time sync since its default start type is manual

### DIFF
--- a/src/AtlasModules/atlas-config.bat
+++ b/src/AtlasModules/atlas-config.bat
@@ -281,6 +281,7 @@ if %ERRORLEVEL%==0 (echo %date% - %time% Visual C++ Runtimes installed...>> %log
 w32tm /config /syncfromflags:manual /manualpeerlist:"0.pool.ntp.org 1.pool.ntp.org 2.pool.ntp.org 3.pool.ntp.org"
 
 :: resync time to pool.ntp.org
+net start w32time
 w32tm /config /update
 w32tm /resync
 %setSvc% W32Time 4


### PR DESCRIPTION
by default, service `w32time` is started manually. so lines of `w32tm /config /update` & `w32tm /resync` always report an error that the service is not started. this pr add a line to start the service.