### PR TITLE
remove ps execution policy setting and trim setting

### DIFF
--- a/src/AtlasModules/atlas-config.bat
+++ b/src/AtlasModules/atlas-config.bat
@@ -298,10 +298,6 @@ fsutil behavior set disablelastaccess 1
 :: https://ttcshelbyville.wordpress.com/2018/12/02/should-you-disable-8dot3-for-performance-and-security
 fsutil behavior set disable8dot3 1
 
-:: enable delete notifications (aka trim or unmap)
-:: should be enabled by default but it is here to be sure
-fsutil behavior set disabledeletenotify 0
-
 :: disable file system mitigations
 reg add "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager" /v "ProtectionMode" /t REG_DWORD /d "0" /f
 
@@ -396,9 +392,6 @@ cls & echo Please wait. This may take a moment.
 
 :: delete defaultuser0 account used during oobe
 net user defaultuser0 /delete > nul 2>nul
-
-:: set PowerShell execution policy to unrestricted
-%PowerShell% "Set-ExecutionPolicy Unrestricted -Force"
 
 :: disable reserved storage
 DISM /Online /Set-ReservedStorageState /State:Disabled


### PR DESCRIPTION
This PR includes 2x changes:



Disable notification lines are removed since they are not necessary. This feature is always enabled in every supported version of Windows, and post-install script is always executed immediately after system installation. So we don't need to be sure of anything.



Seeting powershell execution policy to unretricted is also removed because:

1. this line does not work at all, `%PowerShell%` here will be expanded with https://github.com/Atlas-OS/Atlas/blob/99a596bfd92e4d2ed58e84adbd3b30eac56bc8bc/src/AtlasModules/atlas-config.bat#L38 to `C:\Windows\System32\WindowsPowerShell\v1.0\PowerShell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "Set-ExecutionPolicy Unrestricted -Force"`. And there would be an error since execution policy is set twice in this line with difference scope.
2. with https://github.com/Atlas-OS/Atlas/blob/99a596bfd92e4d2ed58e84adbd3b30eac56bc8bc/src/AtlasModules/atlas-config.bat#L38, every execution of powershell in scripts are already elevated with `bypass` execution policy. Thus we don't need this line at all.
3. unrestricted execution policy itself also brings security vulnerability.