### PR TITLE
fix typo for Virtualization-based Security

### DIFF
--- a/src/AtlasModules/atlas-config.bat
+++ b/src/AtlasModules/atlas-config.bat
@@ -1614,7 +1614,7 @@ bcdedit /set description Atlas %branch% %ver%
 :: disable hyper-v and vbs
 bcdedit /set hypervisorlaunchtype off
 bcdedit /set vm no
-bcdedit /set vmslaunchtype Off
+bcdedit /set vsmlaunchtype Off
 bcdedit /set loadoptions DISABLE-LSA-ISO,DISABLE-VBS
 
 echo %date% - %time% BCD options set...>> %log%
@@ -1698,7 +1698,7 @@ goto finish
 :: bcdedit commands
 bcdedit /set hypervisorlaunchtype off > nul
 bcdedit /set vm no > nul
-bcdedit /set vmslaunchtype Off > nul
+bcdedit /set vsmlaunchtype Off > nul
 bcdedit /set loadoptions DISABLE-LSA-ISO,DISABLE-VBS > nul
 
 :: disable hyper-v with DISM


### PR DESCRIPTION
There are two lines toggling Virtualization-based Security but with typo error. Another line is right: https://github.com/Atlas-OS/Atlas/blob/f07849fdd9db54ad6932da4a7008c7eb5e288560/src/AtlasModules/atlas-config.bat#L1774

By the way, by checking microsoft documents, it looks this switch should not affect enable / disable of Hyper-V at all. Maybe we could remove these lines?