### PR TITLE
change Scoop link to JsDelivr

### DIFF
--- a/src/AtlasModules/atlas-config.bat
+++ b/src/AtlasModules/atlas-config.bat
@@ -2654,8 +2654,8 @@ goto finish
 :scoop
 echo Installing Scoop...
 set /P c="Review install script before executing? [Y/N]: "
-if /I "%c%" EQU "Y" curl "https://raw.githubusercontent.com/ScoopInstaller/install/master/install.ps1" -o %WinDir%\AtlasModules\install.ps1 && notepad %WinDir%\AtlasModules\install.ps1
-if /I "%c%" EQU "N" curl "https://raw.githubusercontent.com/ScoopInstaller/install/master/install.ps1" -o %WinDir%\AtlasModules\install.ps1
+if /I "%c%" EQU "Y" curl "https://cdn.jsdelivr.net/gh/ScoopInstaller/Install@master/install.ps1" -o %WinDir%\AtlasModules\install.ps1 && notepad %WinDir%\AtlasModules\install.ps1
+if /I "%c%" EQU "N" curl "https://cdn.jsdelivr.net/gh/ScoopInstaller/Install@master/install.ps1" -o %WinDir%\AtlasModules\install.ps1
 %PowerShell% "%WinDir%\AtlasModules\install.ps1 -RunAsAdmin"
 echo Refreshing environment for Scoop...
 call %WinDir%\AtlasModules\refreshenv.bat


### PR DESCRIPTION
Changing`https://raw.githubusercontent.com/ScoopInstaller/install/master/install.ps1` 
to `https://cdn.jsdelivr.net/gh/ScoopInstaller/Install@master/install.ps1`

-`https://raw.githubusercontent.com` is restricted to access / slow to access in certain regions and ISP's. 
(e.g. China, [India (Jio Network) ](https://github.com/anuraghazra/github-readme-stats/issues/2446#issuecomment-1399228965))

