### PR TITLE
Update DISABLEPNP.ps1

### DIFF
--- a/src/Executables/DISABLEPNP.ps1
+++ b/src/Executables/DISABLEPNP.ps1
@@ -3,7 +3,6 @@ $devices = @(
 	"AMD PSP",
 	"AMD SMBus",
 	"Base System Device",
-	"*Bluetooth*",
 	"Composite Bus Enumerator",
 	"Direct memory access controller"
 	"High precision event timer",


### PR DESCRIPTION
Remove redundant line that is already included in the bluetooth main deactivation script which is controlled by the playbook feature

### Questions
- [X] Did you test your changes or double check that they work?
- [X] Did you read and follow the [Atlas Contribution Guidelines](https://docs.atlasos.net/contributions/)?
- [X] Did you commit to the [`dev`](https://github.com/Atlas-OS/Atlas/tree/dev) branch and not [`main`](https://github.com/Atlas-OS/Atlas)?

**Note:** You should commit directly to `main` for translations of the `README.md`.

### Describe your pull request
Remove redundant line that is already included in the bluetooth main deactivation script which is controlled by the playbook feature