### PR TITLE
Add Winget Error Checking to Scripts

### DIFF
--- a/src/playbook/Executables/AtlasDesktop/3. Configuration/Start Menu/Install Open-Shell.cmd
+++ b/src/playbook/Executables/AtlasDesktop/3. Configuration/Start Menu/Install Open-Shell.cmd
@@ -39,7 +39,7 @@ call "%windir%\AtlasDesktop\3. Configuration\Start Menu\Disable Start Menu and S
 echo]
 
 :: Download and install Open-Shell
-winget install -e --id Open-Shell.Open-Shell-Menu -h --accept-source-agreements --accept-package-agreements --force
+winget install -e --id Open-Shell.Open-Shell-Menu -h --accept-source-agreements --accept-package-agreements --force > nul
 if !errorlevel! NEQ 0 (
     echo Error: Open-Shell installation failed.
     pause

--- a/src/playbook/Executables/AtlasDesktop/3. Configuration/Start Menu/Install Open-Shell.cmd
+++ b/src/playbook/Executables/AtlasDesktop/3. Configuration/Start Menu/Install Open-Shell.cmd
@@ -40,6 +40,11 @@ echo]
 
 :: Download and install Open-Shell
 winget install -e --id Open-Shell.Open-Shell-Menu -h --accept-source-agreements --accept-package-agreements --force
+if !errorlevel! NEQ 0 (
+    echo Error: Open-Shell installation failed.
+    pause
+    exit /b 1
+)
 
 :: Download Fluent Metro theme
 for /f "delims=" %%a in ('PowerShell "(Invoke-RestMethod -Uri "https://api.github.com/repos/bonzibudd/Fluent-Metro/releases/latest").assets.browser_download_url"') do (

--- a/src/playbook/Executables/AtlasDesktop/6. Advanced Configuration/Utilities/Process Explorer/Install and Replace Task Manager.cmd
+++ b/src/playbook/Executables/AtlasDesktop/6. Advanced Configuration/Utilities/Process Explorer/Install and Replace Task Manager.cmd
@@ -25,6 +25,11 @@ where winget > nul 2>&1 || (
 
 echo Installing Process Explorer...
 winget install -e --id Microsoft.Sysinternals.ProcessExplorer --uninstall-previous -l "%windir%\AtlasModules\Apps\ProcessExplorer" -h --accept-source-agreements --accept-package-agreements --force --disable-interactivity > nul
+if !errorlevel! NEQ 0 (
+    echo Error: Process Explorer installation failed.
+    pause
+    exit /b 1
+)
 
 echo Creating the Start menu shortcut...
 PowerShell -NoP -C "$WshShell = New-Object -comObject WScript.Shell; $Shortcut = $WshShell.CreateShortcut("""$env:ProgramData\Microsoft\Windows\Start Menu\Programs\Process Explorer.lnk"""); $Shortcut.TargetPath = """$env:WinDir\AtlasModules\Apps\ProcessExplorer\procexp.exe"""; $Shortcut.Save()" > nul


### PR DESCRIPTION
### Questions
- [X] Did you test your changes or double check that they work?
- [X] Did you read and follow the [Atlas Contribution Guidelines](https://docs.atlasos.net/contributions/)?
- [X] Did you commit to the [`dev`](https://github.com/Atlas-OS/Atlas/tree/dev) branch and not [`main`](https://github.com/Atlas-OS/Atlas)?

**Note:** You should commit directly to `main` for translations of the `README.md`.

### Describe your pull request (edited)
Adds Winget error checking in the `Install Open-Shell` and `Install and Replace Task Manager` scripts

This fixes [v03-testing > Install Open-shell script error](https://ptb.discord.com/channels/795710270000332800/1149430331913543770)