### PR TITLE
Replace absolute paths with environment variables

### DIFF
--- a/src/playbook/Configuration/tweaks/qol/config-powershell.yml
+++ b/src/playbook/Configuration/tweaks/qol/config-powershell.yml
@@ -11,12 +11,12 @@ actions:
   - !registryValue:
     path: 'HKCR\Applications\powershell.exe\shell\open\command'
     value: ''
-    data: '"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" -NoLogo -EP Unrestricted -File "%1" %*'
+    data: '"%windir%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoLogo -EP Unrestricted -File "%1" %*'
     type: REG_SZ
   - !registryValue:
     path: 'HKCR\ps1_auto_file\shell\open\command'
     value: ''
-    data: '"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" -NoLogo -EP Unrestricted -File "%1" %*'
+    data: '"%windir%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoLogo -EP Unrestricted -File "%1" %*'
     type: REG_SZ
   - !registryValue:
     path: 'HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\FileExts\.ps1\OpenWithList'


### PR DESCRIPTION
The variables were there before but in a recent commit they were replaced by absolute paths

### Questions
- [X] Did you test your changes or double check that they work?
- [X] Did you read and follow the [Atlas Contribution Guidelines](https://docs.atlasos.net/contributions/)?
- [X] Did you commit to the [`dev`](https://github.com/Atlas-OS/Atlas/tree/dev) branch and not [`main`](https://github.com/Atlas-OS/Atlas)?

**Note:** You should commit directly to `main` for translations of the `README.md`.

### Describe your pull request
This change restores the environment variables that were lost in a recent commit