### PR TITLE
Fix: ARM64 Detection

### DIFF
--- a/src/playbook/Executables/AtlasModules/PackagesEnvironment/winrePackages.ps1
+++ b/src/playbook/Executables/AtlasModules/PackagesEnvironment/winrePackages.ps1
@@ -4,7 +4,7 @@ param (
     [switch]$DeleteBitLockerPassword
 )
 
-if ((Get-WmiObject -Class Win32_ComputerSystem).SystemType -match '*ARM64*') {
+if ($env:PROCESSOR_ARCHITECTURE -match 'ARM64') {
     Write-Host "This script is not supported on ARM64." -ForegroundColor Yellow
     pause
 }


### PR DESCRIPTION
### Questions
- [x] Did you test your changes or double check that they work?
- [x] Did you read and follow the [Atlas Contribution Guidelines](https://docs.atlasos.net/contributions/)?
- [x] Did you commit to the [`dev`](https://github.com/Atlas-OS/Atlas/tree/dev) branch and not [`main`](https://github.com/Atlas-OS/Atlas)?

**Note:** You should commit directly to `main` for translations of the `README.md`.

### Describe your pull request

Current ARM64 detection method is invalid and causes errors, even on non ARM64 systems. This method properly checks for ARM64.