### PR TITLE
Fix: Invalid shortcut to  docs "post-installation/software/getting-started" in AtlasDesktop

### DIFF
--- a/src/playbook/Executables/AtlasDesktop/1. Software/How To Install Software.url
+++ b/src/playbook/Executables/AtlasDesktop/1. Software/How To Install Software.url
@@ -2,4 +2,4 @@
 Prop3=19,11
 [InternetShortcut]
 IDList=
-URL=https://docs.atlasos.net/getting-started/post-installation/software/
+URL=https://docs.atlasos.net/getting-started/post-installation/software/getting-started/


### PR DESCRIPTION
### Questions
- [x] Did you test your changes or double check that they work?
- [x] Did you read and follow the [Atlas Contribution Guidelines](https://docs.atlasos.net/contributions/)?
- [x] Did you commit to the [`dev`](https://github.com/Atlas-OS/Atlas/tree/dev) branch and not [`main`](https://github.com/Atlas-OS/Atlas)?

### Describe your pull request

This will fix https://github.com/Atlas-OS/Atlas/issues/1056