### PR TITLE
Disable the Downfall bug patch

### DIFF
--- a/src/playbook/Executables/AtlasDesktop/7. Security/Mitigations/Disable All Mitigations.cmd
+++ b/src/playbook/Executables/AtlasDesktop/7. Security/Mitigations/Disable All Mitigations.cmd
@@ -9,9 +9,10 @@ whoami /user | find /i "S-1-5-18" > nul 2>&1 || (
 )
 
 :main
-:: Disable Spectre and Meltdown
+:: Disable Spectre, Meltdown and Downfall
 reg add "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management" /v "FeatureSettingsOverride" /t REG_DWORD /d "3" /f > nul
-reg add "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management" /v "FeatureSettingsOverrideMask" /t REG_DWORD /d "3" /f > nul
+:: 33554435 (0x2000003) also disables Downfall
+reg add "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management" /v "FeatureSettingsOverrideMask" /t REG_DWORD /d "33554435" /f > nul
 
 :: Disable Structured Exception Handling Overwrite Protection (SEHOP)
 :: Exists in ntoskrnl strings, keep for now


### PR DESCRIPTION
### Questions
- [x] Did you test your changes or double check that they work?
- [x] Did you read and follow the [Atlas Contribution Guidelines](https://docs.atlasos.net/contributions/)?
- [x] Did you commit to the [`dev`](https://github.com/Atlas-OS/Atlas/tree/dev) branch and not [`main`](https://github.com/Atlas-OS/Atlas)?

### Describe your pull request
It's been recommended by several tweakers to disable the patch. It's also been reported by people on Reddit and in numerous articles it drops performance. You may think going too deep into ditching security patches doesn't give good enough of a trade-off, and you'd be right. Up to the maintainers.