### PR TITLE
feat: refactor Playbook options

### DIFF
--- a/src/playbook/Configuration/atlas/services.yml
+++ b/src/playbook/Configuration/atlas/services.yml
@@ -21,18 +21,6 @@ actions:
   ## SCRIPTS                                                                                  ##
   ##############################################################################################
 
-  - !writeStatus: {status: 'Disabling Printing', option: 'disable-printing'}
-  - !cmd:
-    command: '"AtlasDesktop\3. General Configuration\Printing\Disable Printing.cmd" /silent'
-    option: 'disable-printing'
-    exeDir: true
-    wait: true
-  - !writeStatus: {status: 'Disabling Bluetooth', option: 'disable-bluetooth'}
-  - !cmd:
-    command: '"AtlasDesktop\3. General Configuration\Bluetooth\Disable Bluetooth.cmd" /silent'
-    option: 'disable-bluetooth'
-    exeDir: true
-    wait: true
   - !writeStatus: {status: 'Disabling File Sharing'}
   - !powerShell:
     command: '.\AtlasModules\Scripts\ScriptWrappers\DisableFileSharing.ps1 -Silent'
@@ -69,7 +57,7 @@ actions:
 
   - !writeStatus: {status: 'Configuring drivers'}
 
-    # NetBios support can be enabled with the file sharing script
   - !service: {name: 'GpuEnergyDrv', operation: change, startup: 4}
+    # NetBios support can be enabled with the file sharing script
   - !service: {name: 'NetBT', operation: change, startup: 4}
   - !service: {name: 'Telemetry', operation: change, startup: 4}

--- a/src/playbook/Configuration/tweaks/misc/enable-notifications.yml
+++ b/src/playbook/Configuration/tweaks/misc/enable-notifications.yml
@@ -6,9 +6,3 @@ actions:
     command: '"AtlasDesktop\3. General Configuration\Notifications\Enable Notifications.cmd" /silent'
     exeDir: true
     wait: true
-    option: '!disable-notifications'
-  - !cmd:
-    command: '"AtlasDesktop\3. General Configuration\Notifications\Enable Notifications.cmd" /justuserservice'
-    exeDir: true
-    wait: true
-    option: 'disable-notifications'

--- a/src/playbook/Configuration/tweaks/qol/windows-update/disable-auto-updates.yml
+++ b/src/playbook/Configuration/tweaks/qol/windows-update/disable-auto-updates.yml
@@ -7,7 +7,7 @@ actions:
     command: 'reg import "AtlasDesktop\3. General Configuration\Windows Update\Automatic Updates\Disable Automatic Updates (default).reg"'
     exeDir: true
     wait: true
-    option: 'disable-auto-updates'
+    option: 'auto-updates-disable'
 
     # Prevent DevHome & Outlook from re-installing
   - !registryKey: {path: 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Orchestrator\UScheduler\DevHomeUpdate'}

--- a/src/playbook/Configuration/tweaks/scripts/script-core-isolation.yml
+++ b/src/playbook/Configuration/tweaks/scripts/script-core-isolation.yml
@@ -1,7 +1,7 @@
 ---
 title: Disable Core Isolation
 description: Disables Core Isolation (VBS) based on the user's options
-option: 'vbs-disable'
+option: 'disable-core-isolation'
 actions:
   - !powerShell:
     command: '& """.\AtlasModules\Scripts\ScriptWrappers\ConfigVBS.ps1""" -DisableAllVBS'

--- a/src/playbook/playbook.conf
+++ b/src/playbook/playbook.conf
@@ -46,8 +46,8 @@ Atlas makes your computer snappier and more private with lots of usability impro
 			</Options>
 			<BottomLine Text="Learn more" Link="https://docs.atlasos.net/getting-started/post-installation/atlas-folder/security/#defender"/>
 		</RadioPage>
-		<RadioPage IsRequired="true" DefaultOption="mitigations-default" Description="Disabling mitigations reduces security, and only improves performance on older CPUs.">
-			<TopLine Text="Disabling could hurt performance on modern CPUs."/>
+		<RadioPage IsRequired="true" DefaultOption="mitigations-default" Description="Disabling mitigations reduces security, and could harm performance on modern CPUs.">
+			<TopLine Text="Disabling could improve performance on older CPUs."/>
 			<Options>
 				<RadioOption>
 					<Text>Default Windows Mitigations (recommended)</Text>
@@ -60,37 +60,20 @@ Atlas makes your computer snappier and more private with lots of usability impro
 			</Options>
 			<BottomLine Text="Learn more" Link="https://docs.atlasos.net/getting-started/post-installation/atlas-folder/security/#mitigations"/>
 		</RadioPage>
-		<RadioPage IsRequired="true" DefaultOption="vbs-disable" Description="Enabling core isolation protects important parts of Windows, but at the cost of performance.">
+		<RadioPage IsRequired="true" DefaultOption="auto-updates-disable" Description="Updates are important for security, you'll get update notifications regardless.">
 			<TopLine Text="This can be changed in the Atlas folder later."/>
 			<Options>
 				<RadioOption>
-					<Text>Disable Core Isolation (recommended)</Text>
-					<Name>vbs-disable</Name>
+					<Text>Disable Automatic Windows Updates</Text>
+					<Name>auto-updates-disable</Name>
 				</RadioOption>
 				<RadioOption>
-					<Text>Windows Default</Text>
-					<Name>vbs-default</Name>
+					<Text>Enable Automatic Windows Updates</Text>
+					<Name>auto-updates-default</Name>
 				</RadioOption>
 			</Options>
-			<BottomLine Text="Learn more" Link="https://docs.atlasos.net/getting-started/post-installation/atlas-folder/security/#core-isolation"/>
+			<BottomLine Text="Learn more" Link="https://docs.atlasos.net/getting-started/post-installation/atlas-folder/general-configuration/#automatic-updates"/>
 		</RadioPage>
-		<CheckboxPage IsRequired="true" Description="Select the options you would like to use, they can be changed in the Atlas folder later.">
-			<Options>
-				<CheckboxOption>
-					<Text>Disable Printing</Text>
-					<Name>disable-printing</Name>
-				</CheckboxOption>
-				<CheckboxOption>
-					<Text>Disable Bluetooth</Text>
-					<Name>disable-bluetooth</Name>
-				</CheckboxOption>
-				<CheckboxOption>
-					<Text>Disable Power Saving</Text>
-					<Name>disable-power-saving</Name>
-				</CheckboxOption>
-			</Options>
-			<BottomLine Text="Learn more" Link="https://docs.atlasos.net/getting-started/post-installation/atlas-folder/configuration"/>
-		</CheckboxPage>
 		<CheckboxPage IsRequired="true" Description="Select the options you would like to use, they can be changed in the Atlas folder later.">
 			<Options>
 				<CheckboxOption>
@@ -98,21 +81,20 @@ Atlas makes your computer snappier and more private with lots of usability impro
 					<Name>disable-hibernation</Name>
 				</CheckboxOption>
 				<CheckboxOption>
-					<Text>Disable Automatic Updates</Text>
-					<Name>disable-auto-updates</Name>
+					<Text>Disable Power Saving</Text>
+					<Name>disable-power-saving</Name>
 				</CheckboxOption>
 				<CheckboxOption>
-					<Text>Remove Snipping Tool App</Text>
-					<Name>remove-snipping-tool</Name>
+					<Text>Disable Core Isolation</Text>
+					<Name>disable-core-isolation</Name>
 				</CheckboxOption>
 			</Options>
-			<BottomLine Text="Learn more" Link="https://docs.atlasos.net/getting-started/post-installation/atlas-folder/configuration"/>
 		</CheckboxPage>
 		<CheckboxPage IsRequired="true" Description="Select the options you would like to use, they can be changed in the Atlas folder later.">
 			<Options>
 				<CheckboxOption>
-					<Text>Disable Notifications</Text>
-					<Name>disable-notifications</Name>
+					<Text>Remove Snipping Tool App</Text>
+					<Name>remove-snipping-tool</Name>
 				</CheckboxOption>
 				<CheckboxOption>
 					<Text>Remove Microsoft Edge</Text>

--- a/src/playbook/playbook.conf
+++ b/src/playbook/playbook.conf
@@ -89,6 +89,7 @@ Atlas makes your computer snappier and more private with lots of usability impro
 					<Name>disable-core-isolation</Name>
 				</CheckboxOption>
 			</Options>
+			<BottomLine Text="Learn more" Link="https://docs.atlasos.net/getting-started/post-installation/atlas-folder/configuration"/>
 		</CheckboxPage>
 		<CheckboxPage IsRequired="true" Description="Select the options you would like to use, they can be changed in the Atlas folder later.">
 			<Options>


### PR DESCRIPTION
- The page related to services has been removed
	- Many users go through the options without reading
	- This leads to them disabling functionality that they then can't re-enable in the usual ways in Windows, which causes confusion
	- This is all for a very negligible performance boost
	- Disabling notifications is a security risk as users can't get [update notifications](https://docs.atlasos.net/getting-started/post-installation/atlas-folder/general-configuration/#automatic-updates)
- Auto-updates and core isolation have swapped places
	- Auto-updates is now a radio page and provides more info on updates
	- Info on core isolation is arguably less critical than info on auto-updates
- Mitigations has had its TopLine (the grey text underneath) swapped with the description
	- This is to make users more aware of the negative impact on modern CPUs
