### PR TITLE
 feat: disable 'alt + space' lang bar shortcuts

### DIFF
--- a/src/playbook/Configuration/tweaks/qol/ease-of-access/disable-annoying-features-shortcuts.yml
+++ b/src/playbook/Configuration/tweaks/qol/ease-of-access/disable-annoying-features-shortcuts.yml
@@ -27,3 +27,22 @@ actions:
     value: 'Flags'
     data: '0'
     type: REG_DWORD
+
+    # Disable langunage bar shortcuts
+  - !registryKey:
+    path: 'HKCU\Control Panel\Input Method\Hot Keys\00000104'
+  - !registryValue:
+    path: 'HKCU\Keyboard Layout\Toggle'
+    value: 'Layout Hotkey'
+    data: '3'
+    type: REG_DWORD
+  - !registryValue:
+    path: 'HKCU\Keyboard Layout\Toggle'
+    value: 'Language Hotkey'
+    data: '3'
+    type: REG_DWORD
+  - !registryValue:
+    path: 'HKCU\Keyboard Layout\Toggle'
+    value: 'Hotkey'
+    data: '3'
+    type: REG_DWORD


### PR DESCRIPTION
### Questions
- [x] Did you test your changes or double-check that they work?
- [x] Did you read and follow the [Atlas Contribution Guidelines](https://docs.atlasos.net/contributions/)?

### Describe your pull request
Turns off the <kbd>Left Alt</kbd> + <kbd>Space</kbd> keyboard that changes the keyboard layout if there are multiple installed. Users can easily trigger this shortcut within games, which is annoying.