### PR TITLE
fix: clean component store after optional features

### DIFF
--- a/src/playbook/Configuration/atlas/start.yml
+++ b/src/playbook/Configuration/atlas/start.yml
@@ -42,6 +42,9 @@ actions:
   - !writeStatus: {status: 'Disabling Steps Recorder'}
   - !run: {exe: 'DISM.exe', args: '/Online /Remove-Capability /CapabilityName:"App.StepsRecorder~~~~0.0.1.0" /NoRestart', weight: 30}
 
+  - !writeStatus: {status: 'Cleaning the component store'}
+  - !run: {exe: 'DISM.exe', args: '/Online /Cleanup-Image /StartComponentCleanup', weight: 50}
+
     # Initial software
     # 7-Zip, Visual C++ Runtimes, DirectX
   - !writeStatus: {status: 'Installing utilities'}

--- a/src/playbook/Executables/CLEANUP.ps1
+++ b/src/playbook/Executables/CLEANUP.ps1
@@ -23,7 +23,7 @@ function Invoke-AtlasDiskCleanup {
 		"System error minidump files" = 2
 		"Temporary Files" = 0
 		"Thumbnail Cache" = 2
-		"Update Cleanup" = 2
+		"Update Cleanup" = 0
 		"User file versions" = 2
 		"Windows Error Reporting Files" = 2
 		"Windows Defender" = 2


### PR DESCRIPTION
### Questions
- [x] Did you test your changes or double-check that they work?
- [x] Did you read and follow the [Atlas Contribution Guidelines](https://docs.atlasos.net/contributions/)?

### Describe your pull request

Disables cleaning the component store and Windows Update in Disk Cleanup (`cleanmgr`) as I'm guessing this causes DISM to randomly hang when changing features.
