### PR TITLE
feat: 24H2 features & fixes

### DIFF
--- a/src/playbook/Configuration/atlas/appx.yml
+++ b/src/playbook/Configuration/atlas/appx.yml
@@ -31,7 +31,7 @@ actions:
   - !taskKill: {name: 'ms-teams*', ignoreErrors: true}
   - !appx: {name: 'MSTeams*', type: family}
   # 24H2 Copilot app
-  - !appx: {name: 'Microsoft.Copilot', type: family}
+  - !appx: {name: 'Microsoft.Copilot*', type: family}
 
   # Other apps
   - !appx: {name: 'Clipchamp.Clipchamp*', type: family}
@@ -86,6 +86,7 @@ actions:
     wait: true
 
   # Clear caches of Client.CBS and more
+  # Start menu cache is cleared later
   - !writeStatus: {status: 'Clearing AppX caches'}
   - !appx: {operation: clearCache, name: '*MicrosoftWindows.Client.CBS*'}
   - !appx: {operation: clearCache, name: '*Microsoft.Windows.Search*'}

--- a/src/playbook/Configuration/atlas/appx.yml
+++ b/src/playbook/Configuration/atlas/appx.yml
@@ -25,6 +25,7 @@ actions:
   # Seems legacy - not in 23H2?
   - !taskKill: {name: 'msteams*', ignoreErrors: true}
   - !appx: {name: 'MicrosoftTeams*', type: family}
+  - !appx: {name: 'MSTeams*', type: family}
   - !registryValue: {path: 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Communications', value: 'ConfigureChatAutoInstall', data: '0', type: REG_DWORD}
 
   - !appx: {name: 'Clipchamp.Clipchamp*', type: family}

--- a/src/playbook/Configuration/atlas/appx.yml
+++ b/src/playbook/Configuration/atlas/appx.yml
@@ -28,14 +28,18 @@ actions:
   - !appx: {name: 'MSTeams*', type: family}
   - !registryValue: {path: 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Communications', value: 'ConfigureChatAutoInstall', data: '0', type: REG_DWORD}
 
+  # 24H2 Copilot app
+  - !appx: {name: 'Microsoft.Copilot', type: family}
+
+  # Other apps
   - !appx: {name: 'Clipchamp.Clipchamp*', type: family}
   - !appx: {name: 'Disney.37853FC22B2CE*', type: family}
   - !appx: {name: 'SpotifyAB.SpotifyMusic*', type: family}
   - !appx: {name: 'Microsoft.549981C3F5F10*', type: family} # Cortana
-  - !appx: {name: 'Microsoft.XboxApp*', type: family} # Legacy Xbox Console Companion
+  - !appx: {name: 'Microsoft.XboxApp*', type: family} # Xbox Console Companion (deprecated)
   - !appx: {name: 'microsoft.windowscommunicationsapps*', type: family} # Mail and Calendar
   - !appx: {name: 'Microsoft.MSPaint*', type: family} # Paint 3D
-  - !appx: {name: 'Microsoft.Getstarted*', type: family} # Tips
+  - !appx: {name: 'Microsoft.Getstarted*', type: family} # Tips (deprecated)
   - !appx: {name: 'Microsoft.ZuneVideo*', type: family} # Films & TV
   - !appx: {name: 'MicrosoftCorporationII.MicrosoftFamily*', type: family}
   - !appx: {name: 'Microsoft.MixedReality.Portal*', type: family}

--- a/src/playbook/Configuration/atlas/appx.yml
+++ b/src/playbook/Configuration/atlas/appx.yml
@@ -22,12 +22,14 @@ actions:
     wait: true
 
   # AppX Microsoft Teams
-  # Seems legacy - not in 23H2?
+  # Seems legacy - not in 23H2
   - !taskKill: {name: 'msteams*', ignoreErrors: true}
   - !appx: {name: 'MicrosoftTeams*', type: family}
-  - !appx: {name: 'MSTeams*', type: family}
   - !registryValue: {path: 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Communications', value: 'ConfigureChatAutoInstall', data: '0', type: REG_DWORD}
 
+  # New AppX Teams in 24H2
+  - !taskKill: {name: 'ms-teams*', ignoreErrors: true}
+  - !appx: {name: 'MSTeams*', type: family}
   # 24H2 Copilot app
   - !appx: {name: 'Microsoft.Copilot', type: family}
 

--- a/src/playbook/Executables/AtlasDesktop/3. General Configuration/Microsoft Copilot/Disable Microsoft Copilot (default).cmd
+++ b/src/playbook/Executables/AtlasDesktop/3. General Configuration/Microsoft Copilot/Disable Microsoft Copilot (default).cmd
@@ -1,0 +1,26 @@
+@echo off
+
+set "___args="%~f0" %*"
+fltmc > nul 2>&1 || (
+	echo Administrator privileges are required.
+	powershell -c "Start-Process -Verb RunAs -FilePath 'cmd' -ArgumentList """/c $env:___args"""" 2> nul || (
+		echo You must run this script as admin.
+		if "%*"=="" pause
+		exit /b 1
+	)
+	exit /b
+)
+
+echo Disabling and uninstalling Copilot...
+
+powershell -NoP -NonI "Get-AppxPackage -AllUsers Microsoft.Copilot* | Remove-AppxPackage -AllUsers"
+taskkill /f /im explorer.exe > nul 2>&1
+reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "ShowCopilotButton" /t REG_DWORD /d "0" /f > nul
+reg add "HKCU\Software\Policies\Microsoft\Windows\WindowsCopilot" /v "TurnOffWindowsCopilot" /t REG_DWORD /d "1" /f > nul
+start explorer.exe
+
+echo]
+echo Finished, changes are applied.
+echo Press any key to exit...
+pause > nul
+exit /b

--- a/src/playbook/Executables/AtlasDesktop/3. General Configuration/Microsoft Copilot/Disable Microsoft Copilot (default).reg
+++ b/src/playbook/Executables/AtlasDesktop/3. General Configuration/Microsoft Copilot/Disable Microsoft Copilot (default).reg
@@ -1,4 +1,0 @@
-Windows Registry Editor Version 5.00
-
-[HKEY_CURRENT_USER\Software\Policies\Microsoft\Windows\WindowsCopilot]
-"TurnOffWindowsCopilot"=dword:00000001

--- a/src/playbook/Executables/AtlasDesktop/3. General Configuration/Microsoft Copilot/Enable Microsoft Copilot.cmd
+++ b/src/playbook/Executables/AtlasDesktop/3. General Configuration/Microsoft Copilot/Enable Microsoft Copilot.cmd
@@ -21,6 +21,7 @@ echo Enabling Copilot...
 
 :: Decide if Copilot is avaliable
 :: If not, it could be 24H2 (which replaces it with an app)
+set "appText= "
 reg query HKCU\Software\Microsoft\Windows\Shell\Copilot /v IsCopilotAvailable 2>&1 | find "0x0" > nul
 if %errorlevel%==0 (call :app) else (reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "ShowCopilotButton" /t REG_DWORD /d "1" /f > nul)
 
@@ -30,13 +31,15 @@ start explorer.exe
 
 :finish
 echo]
-echo Finished, changes are applied.
+echo Finished, changes are applied. %appText%
 echo Press any key to exit...
 pause > nul
 exit /b
 
 :app
-echo NOTE: Copilot on the taskbar isn't available, installing the app instead...
-call "%windir%\AtlasModules\Scripts\wingetCheck.cmd"
+echo NOTE: Copilot on the taskbar isn't available, the app will be installed instead.
+set "appText=You can find the Copilot app in your Start Menu."
+call "%windir%\AtlasModules\Scripts\wingetCheck.cmd" /nodashes
 if %errorlevel% neq 0 exit /b 1
+echo Installing Copilot...
 winget install -e --id 9NHT9RB2F4HD --uninstall-previous -h --accept-source-agreements --accept-package-agreements --force --disable-interactivity > nul

--- a/src/playbook/Executables/AtlasDesktop/3. General Configuration/Microsoft Copilot/Enable Microsoft Copilot.cmd
+++ b/src/playbook/Executables/AtlasDesktop/3. General Configuration/Microsoft Copilot/Enable Microsoft Copilot.cmd
@@ -20,7 +20,7 @@ echo]
 echo Enabling Copilot...
 
 :: Decide if Copilot is avaliable
-:: If not, it could be 24H2 (which replaces it with an app
+:: If not, it could be 24H2 (which replaces it with an app)
 reg query HKCU\Software\Microsoft\Windows\Shell\Copilot /v IsCopilotAvailable 2>&1 | find "0x0" > nul
 if %errorlevel%==0 (call :app) else (reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "ShowCopilotButton" /t REG_DWORD /d "1" /f > nul)
 

--- a/src/playbook/Executables/AtlasModules/Scripts/wingetCheck.cmd
+++ b/src/playbook/Executables/AtlasModules/Scripts/wingetCheck.cmd
@@ -2,9 +2,11 @@
 
 set "dashes=-----------------------------------------------------------------------------------------------------"
 set "silent="
-echo "%~1 %~2" | find "/silent" > nul && set silent=true
+set "nodashes="
+echo "%*" | find "/silent" > nul && set silent=true
+echo "%*" | find "/nodashes" > nul && set nodashes=true
 
-if not defined silent echo %dashes%
+if not defined silent (if not defined nodashes echo %dashes%)
 
 ping -n 1 -4 www.microsoft.com > nul 2>&1
 if errorlevel == 1 (
@@ -36,8 +38,10 @@ winget search "Microsoft Visual Studio Code" --accept-source-agreements > nul 2>
 )
 
 if not defined silent (
-    echo %dashes%
-    echo]
+    if not defined nodashes (
+        echo %dashes%
+        echo]
+    )
 )
 
 exit /b


### PR DESCRIPTION
### Questions
- [x] Did you test your changes or double-check that they work?
- [x] Did you read and follow the [Atlas Contribution Guidelines](https://docs.atlasos.net/contributions/)?

### Describe your pull request
Does these for 24H2:
- Adds support for the Copilot app
- Fixes the 'Accounts' settings page ads
	- It's also more reliable generally now
- Remove & kill new Appx Teams

**This PR doesn't bring 24H2 support;** it implements needed changes I noticed when testing the Windows Insider Canary branch. These changes are required for when 24H2 is officially released, but they don't really impact 23H2.