### PR TITLE
Create Service Warning script

### DIFF
--- a/src/playbook/Executables/AtlasDesktop/6. Advanced Configuration/Services/Lanman Workstation (SMB)/Disable Lanman Workstation.cmd
+++ b/src/playbook/Executables/AtlasDesktop/6. Advanced Configuration/Services/Lanman Workstation (SMB)/Disable Lanman Workstation.cmd
@@ -11,6 +11,9 @@ fltmc > nul 2>&1 || (
 	exit /b
 )
 
+:: Warn user about service modifications
+call serviceWarning.cmd 
+
 call setSvc.cmd KSecPkg 4
 call setSvc.cmd LanmanServer 4
 call setSvc.cmd LanmanWorkstation 4

--- a/src/playbook/Executables/AtlasDesktop/6. Advanced Configuration/Services/Network Discovery/Disable Network Discovery Services.cmd
+++ b/src/playbook/Executables/AtlasDesktop/6. Advanced Configuration/Services/Network Discovery/Disable Network Discovery Services.cmd
@@ -11,6 +11,9 @@ fltmc > nul 2>&1 || (
 	exit /b
 )
 
+:: Warn user about service modifications
+call serviceWarning.cmd 
+
 :: Unpin 'Network' from Explorer sidebar
 reg import "%windir%\AtlasDesktop\3. General Configuration\File Sharing\Network Navigation Pane\Disable Network Navigation Pane (default).reg" > nul
 

--- a/src/playbook/Executables/AtlasDesktop/6. Advanced Configuration/Services/Superfetch/Disable SuperFetch.cmd
+++ b/src/playbook/Executables/AtlasDesktop/6. Advanced Configuration/Services/Superfetch/Disable SuperFetch.cmd
@@ -13,6 +13,9 @@ fltmc > nul 2>&1 || (
 :main
 setlocal EnableDelayedExpansion
 
+:: Warn user about service modifications
+call serviceWarning.cmd 
+
 :: Remove lower filters for rdyboost driver
 set "key=HKLM\SYSTEM\CurrentControlSet\Control\Class\{71a27cdd-812a-11d0-bec7-08002be2092f}"
 for /f "skip=1 tokens=3*" %%a in ('reg query !key! /v "LowerFilters"') do (set val=%%a)

--- a/src/playbook/Executables/AtlasModules/Scripts/serviceWarning.cmd
+++ b/src/playbook/Executables/AtlasModules/Scripts/serviceWarning.cmd
@@ -1,0 +1,21 @@
+@echo off
+goto main
+
+----------------------------------------
+
+[FEATURES]
+- Reusable warning for the user if a script modifies services and notifies of possible breakage.
+
+[USAGE]
+call serviceWarning.cmd [optional:specific comment for service breakage, use quotes]
+
+----------------------------------------
+
+:main
+echo ------------------------------------------------------
+echo WARNING: This script will modify system services.
+echo Modifying services can lead to potential breakage of features and bugs.
+echo Proceed with caution, and refer to Atlas docs for more information!
+if not "%~1"=="" echo Specific Note: %~1
+echo ------------------------------------------------------
+pause


### PR DESCRIPTION
### Questions
- [ ] Did you test your changes or double-check that they work? - draft
- [x] Did you read and follow the [Atlas Contribution Guidelines](https://docs.atlasos.net/contributions/)?

### Describe your pull request

Working to fulfill [[FEATURE] - Initial warning on all services cmds](https://github.com/orgs/Atlas-OS/projects/7/views/1?pane=issue&itemId=71013164)

This pull request includes changes to add a reusable warning for scripts that modify services. The changes ensure that users are explicitly warned about potential service modifications and their implications.

### Addition of Service Modification Warnings:

* **Reusable Warning Script:**
  * Added a new script `serviceWarning.cmd` that provides a standardized warning message to users about potential service modifications and their consequences. (`src/playbook/Executables/AtlasModules/Scripts/serviceWarning.cmd`)

* **Integration of Warning Script:**
  * Added calls to the `serviceWarning.cmd` script in the following service modification scripts:
    * `Disable Lanman Workstation.cmd`
    * `Disable Network Discovery Services.cmd`
    * `Disable SuperFetch.cmd`
  
I would like to discuss the scope of where we apply this warning and if we should add it to scripts that are defaults or restore functionality?