### PR TITLE
fix: build script for Non-English environment

### DIFF
--- a/src/dependencies/local-build.ps1
+++ b/src/dependencies/local-build.ps1
@@ -117,7 +117,7 @@ try {
 
 	$tempPbConfPath = Separator "$playbookTemp\playbook.conf"
 	if ($patterns.Count -gt 0) {
-		Get-Content "playbook.conf" | Where-Object { $_ -notmatch ($patterns -join '|') } | Set-Content $tempPbConfPath
+		Get-Content -Encoding "utf8" "playbook.conf" | Where-Object { $_ -notmatch ($patterns -join '|') } | Set-Content -Encoding "utf8" $tempPbConfPath
 	}
 
 	$customYmlPath = Separator "Configuration\custom.yml"


### PR DESCRIPTION
### Questions
- [x] Did you test your changes or double-check that they work?
- [x] Did you read and follow the [Atlas Contribution Guidelines](https://docs.atlasos.net/contributions/)?

### Describe your pull request

fix build script for Non-English environment.

I want to test my modified version of playbook, but the output of the test target seems having a broken xml format.

It turns out that I use the Chinese environment and powershell use the Chinese encoding to read and write `playbook.conf` file, that would break the `Description` content which contains special characters.

So here is the fix, simply add `-Encoding` to the read and write commands.