### PR TITLE
Fix the "ERROR: Invalid syntax." for "Disallow Edge Swipe.cmd"

### DIFF
--- a/src/playbook/Executables/AtlasDesktop/4. Interface Tweaks/Edge Swipe/Disallow Edge Swipe.cmd
+++ b/src/playbook/Executables/AtlasDesktop/4. Interface Tweaks/Edge Swipe/Disallow Edge Swipe.cmd
@@ -22,7 +22,7 @@ reg add "HKLM\SOFTWARE\AtlasOS\%settingName%" /v path /t REG_SZ /d "%scriptPath%
 
 :: End of state and path update
 
-reg add "HKLM\Software\Policies\Microsoft\Windows\EdgeUI"/t REG_DWORD /v AllowEdgeSwipe /v "0" /f > nul
+reg add "HKLM\Software\Policies\Microsoft\Windows\EdgeUI" /t REG_DWORD /v AllowEdgeSwipe /d "0" /f > nul
 if "%~1"=="/silent" exit /b
 
 echo Changes applied successfully.


### PR DESCRIPTION
### Questions
- [x] Did you test your changes or double-check that they work?
- [x] Did you read and follow the [Atlas Contribution Guidelines](https://docs.atlasos.net/contributions/)?

### Describe your pull request
This error is faced due to an incorrect syntax used which makes the code not execute properly.
![image](https://github.com/user-attachments/assets/ad25d660-a0aa-4b0b-a562-5302e1adccc7)

After the fix:
![image](https://github.com/user-attachments/assets/d093d842-3d66-4dc5-a0ba-c41333728c99)
![image](https://github.com/user-attachments/assets/3b787042-7e57-41e1-84c0-413a5984844e)


