### PR TITLE
make local playbook build script more solid

### DIFF
--- a/src/dependencies/local-build.ps1
+++ b/src/dependencies/local-build.ps1
@@ -485,10 +485,18 @@ try {
     }
 
     # use store mode for speed and keep 7-zip output quiet
-    $archiveArgs = @('a', '-tzip', '-spf', '-y', '-mx1', '-bso0', '-bse0', '-bsp0')
+    $archiveArgs = @('a', '-tzip', '-y', '-mx1', '-bso0', '-bse0', '-bsp0')
+    if ($IsWindowsPlatform) {
+        $archiveArgs += '-spf'
+    }
     $archiveArgs += $passwordArgs
     $archiveArgs += $apbxPath
-    $archiveArgs += '@"{0}"' -f $filesListPath
+    if ($IsWindowsPlatform) {
+        $archiveArgs += '@"{0}"' -f $filesListPath
+    } else {
+        # p7zip refuses -spf with relative paths so use plain @$list
+        $archiveArgs += "@$filesListPath"
+    }
 
     Invoke-SevenZip -ArgumentList $archiveArgs -ErrorContext 'Creating APBX archive' -ArchivePath $apbxPath
 


### PR DESCRIPTION
### Questions
- [x] Did you test your changes or double-check that they work?
- [x] Did you read and follow the [Atlas Contribution Guidelines](https://docs.atlasos.net/contributions/)?

### Describe your pull request

fix 7zip error handling and temp file cleanup, only stage files when needed, and make the script more solid lol
i was getting vietnam flashbacks from the "process cannot access the file because it is being used by another process" error
it now works perfectly on linux as well

this time im not gonna change another 500file