### PR TITLE
Write `HKCU\Keyboard Layout\Toggle` and `...\Accessibility` values as REG_SZ instead of REG_DWORD

### DIFF
--- a/src/playbook/Executables/AtlasModules/Scripts/Modules/Qol/Qol.psm1
+++ b/src/playbook/Executables/AtlasModules/Scripts/Modules/Qol/Qol.psm1
@@ -38,16 +38,16 @@ function Disable-ReadAndScan {
 
 # Function to disable commonly annoying features and shortcuts
 function Disable-AnnoyingFeaturesAndShortcuts {
-    reg add "HKCU\Control Panel\Accessibility\HighContrast" /v "Flags" /t REG_DWORD /d 0 /f
-    reg add "HKCU\Control Panel\Accessibility\Keyboard Response" /v "Flags" /t REG_DWORD /d 0 /f
-    reg add "HKCU\Control Panel\Accessibility\MouseKeys" /v "Flags" /t REG_DWORD /d 0 /f
-    reg add "HKCU\Control Panel\Accessibility\StickyKeys" /v "Flags" /t REG_DWORD /d 0 /f
-    reg add "HKCU\Control Panel\Accessibility\ToggleKeys" /v "Flags" /t REG_DWORD /d 0 /f
+    reg add "HKCU\Control Panel\Accessibility\HighContrast" /v "Flags" /t REG_SZ /d "0" /f
+    reg add "HKCU\Control Panel\Accessibility\Keyboard Response" /v "Flags" /t REG_SZ /d "0" /f
+    reg add "HKCU\Control Panel\Accessibility\MouseKeys" /v "Flags" /t REG_SZ /d "0" /f
+    reg add "HKCU\Control Panel\Accessibility\StickyKeys" /v "Flags" /t REG_SZ /d "0" /f
+    reg add "HKCU\Control Panel\Accessibility\ToggleKeys" /v "Flags" /t REG_SZ /d "0" /f
 
     reg delete "HKCU\Control Panel\Input Method\Hot Keys\00000104" /f
-    reg add "HKCU\Keyboard Layout\Toggle" /v "Layout Hotkey" /t REG_DWORD /d 3 /f
-    reg add "HKCU\Keyboard Layout\Toggle" /v "Language Hotkey" /t REG_DWORD /d 3 /f
-    reg add "HKCU\Keyboard Layout\Toggle" /v "Hotkey" /t REG_DWORD /d 3 /f
+    reg add "HKCU\Keyboard Layout\Toggle" /v "Layout Hotkey" /t REG_SZ /d "3" /f
+    reg add "HKCU\Keyboard Layout\Toggle" /v "Language Hotkey" /t REG_SZ /d "3" /f
+    reg add "HKCU\Keyboard Layout\Toggle" /v "Hotkey" /t REG_SZ /d "3" /f
 
     reg add "HKCU\Software\Microsoft\Narrator\NoRoam" /v "WinEnterLaunchEnabled" /t REG_DWORD /d 0 /f
 }


### PR DESCRIPTION
### Questions
- [x] Did you read and follow the [Atlas Contribution Guidelines](https://docs.atlasos.net/contributions/)?

### Describe your pull request

The three values rewritten in `HKCU\Keyboard Layout\Toggle` should be of type REG_SZ.

Expectation:

<img width="1052" height="646" alt="Image" src="https://github.com/user-attachments/assets/7894fb5b-460f-46dd-b634-a5c23b4c432a" />

I also checked the `HKCU\Control Panel\Accessibility\...` `Flag` values rewritten in the same function in the registry in a stock install of Windows, and those were also of type REG_SZ, so have patched those too. I have not checked other values in other functions.

We received reports of this causing crashes in Keyman; see https://github.com/keymanapp/keyman/issues/14342. (We have now patched Keyman to work around the unexpected data type.)

