### PR TITLE
fix: update broken Visual C++ 2013 redistributable download URLs

### DIFF
--- a/src/playbook/Executables/SOFTWARE.ps1
+++ b/src/playbook/Executables/SOFTWARE.ps1
@@ -113,8 +113,8 @@ $vcredists = [ordered] @{
     "https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x64.exe" = @("2012-x64", $modernArgs)
     "https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x86.exe" = @("2012-x86", $modernArgs)
     # 2013 - version 12.0.40664.0
-    "https://download.visualstudio.microsoft.com/download/pr/10912041/cee5d6bca2ddbcd039da727bf4acb48a/vcredist_x64.exe" = @("2013-x64", $modernArgs)
-    "https://download.visualstudio.microsoft.com/download/pr/10912113/5da66ddebb0ad32ebd4b922fd82e8e25/vcredist_x86.exe" = @("2013-x86", $modernArgs)
+    "https://download.visualstudio.microsoft.com/download/pr/10912041/cee5d6bca2ddbcd039da727bf4acb48a/vcredist_x64.exe"  = @("2013-x64", $modernArgs)
+    "https://download.visualstudio.microsoft.com/download/pr/10912113/5da66ddebb0ad32ebd4b922fd82e8e25/vcredist_x86.exe"  = @("2013-x86", $modernArgs)
     # 2015-2022 (2015+) - latest version
     "https://aka.ms/vs/17/release/vc_redist.x64.exe"                                                            = @("2015+-x64", $modernArgs)
     "https://aka.ms/vs/17/release/vc_redist.x86.exe"                                                            = @("2015+-x86", $modernArgs)


### PR DESCRIPTION
### Questions
- [Y] Did you test your changes or double-check that they work?
- [Y] Did you read and follow the [Atlas Contribution Guidelines](https://docs.atlasos.net/contributions/)?

### Describe your pull request

## Problem
The current aka.ms URLs for Visual C++ 2013 redistributables defined in SOFTWARE.ps1 (https://aka.ms/highdpimfc2013x64enu and https://aka.ms/highdpimfc2013x86enu) are not working and just redirecting to bing.com search site, causing installation failures for Visual C++ Runtime 2013 during the AtlasOS playbook execution.

Error encountered:

```log
--------------------------------------------------
[Status] Installing utilities
--------------------------------------------------

---
[Info | 22:03:15] Running PowerShell command '.\SOFTWARE.ps1' as the current user elevated...
[Process | Out | 22:03:15] Downloading and installing Visual C++ Runtime 2005-x64...
[Process | Out | 22:03:17] Downloading and installing Visual C++ Runtime 2005-x86...
[Process | Out | 22:03:19] Downloading and installing Visual C++ Runtime 2008-x64...
[Process | Out | 22:03:21] Downloading and installing Visual C++ Runtime 2008-x86...
[Process | Out | 22:03:24] Downloading and installing Visual C++ Runtime 2010-x64...
[Process | Out | 22:03:33] Downloading and installing Visual C++ Runtime 2010-x86...
[Process | Out | 22:03:45] Downloading and installing Visual C++ Runtime 2012-x64...
[Process | Out | 22:03:47] Downloading and installing Visual C++ Runtime 2012-x86...
[Process | Out | 22:03:50] Downloading and installing Visual C++ Runtime 2013-x64...
[Process | Err | 22:03:51] Start-Process : This command cannot be run due to the error: The file or directory is corrupted and unreadable.
[Process | Err | 22:03:51] At C:\Users\Nikita\AppData\Local\Temp\AME\Playbooks\00000000-0000-4000-6174-6C6173203A33\Executables\SOFTWARE.ps1:147 
[Process | Err | 22:03:51] char:9
[Process | Err | 22:03:51] +         Start-Process -FilePath $vcExePath -ArgumentList $vcArgs -Wai ...
[Process | Err | 22:03:51] +         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[Process | Err | 22:03:51]     + CategoryInfo          : InvalidOperation: (:) [Start-Process], InvalidOperationException
[Process | Err | 22:03:51]     + FullyQualifiedErrorId : InvalidOperationException,Microsoft.PowerShell.Commands.StartProcessCommand
[Process | Err | 22:03:51]  
[Process | Out | 22:03:51] Downloading and installing Visual C++ Runtime 2013-x86...
[Process | Err | 22:03:51] Start-Process : This command cannot be run due to the error: The file or directory is corrupted and unreadable.
[Process | Err | 22:03:51] At C:\Users\Nikita\AppData\Local\Temp\AME\Playbooks\00000000-0000-4000-6174-6C6173203A33\Executables\SOFTWARE.ps1:147 
[Process | Err | 22:03:51] char:9
[Process | Err | 22:03:51] +         Start-Process -FilePath $vcExePath -ArgumentList $vcArgs -Wai ...
[Process | Err | 22:03:51] +         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[Process | Err | 22:03:51]     + CategoryInfo          : InvalidOperation: (:) [Start-Process], InvalidOperationException
[Process | Err | 22:03:51]     + FullyQualifiedErrorId : InvalidOperationException,Microsoft.PowerShell.Commands.StartProcessCommand
[Process | Err | 22:03:51]  
[Process | Out | 22:03:51] Downloading and installing Visual C++ Runtime 2015+-x64...
[Process | Out | 22:04:03] Downloading and installing Visual C++ Runtime 2015+-x86...
[Process | Out | 22:04:15] Downloading NanaZip...
[Process | Out | 22:04:15] Downloading 'NanaZip_5.0.1263.0.msixbundle'...
[Process | Out | 22:04:17] Downloading 'NanaZip_5.0.1263.0.xml'...
[Process | Out | 22:04:17] Installing NanaZip...
[Process | Out | 22:04:19] Installed NanaZip!
[Process | Out | 22:04:23] Extracting legacy DirectX runtimes...
[Process | Out | 22:04:26] Installing legacy DirectX runtimes...
---
```

## Solution
Updated to use direct download.visualstudio.microsoft.com URLs that provide working downloads:
- x64: https://download.visualstudio.microsoft.com/download/pr/10912041/cee5d6bca2ddbcd039da727bf4acb48a/vcredist_x64.exe
- x86: https://download.visualstudio.microsoft.com/download/pr/10912113/5da66ddebb0ad32ebd4b922fd82e8e25/vcredist_x86.exe

Both URLs provide Visual C++ 2013 version 12.0.40664.0 and have been tested to work correctly.

## Changes
- Updated `src/playbook/Executables/SOFTWARE.ps1` with the new download URLs