### PR TITLE
fix: use language-independent device identifiers for PnP device disabling

### DIFF
--- a/src/playbook/Executables/AtlasModules/Scripts/Modules/Scripts/Scripts.psm1
+++ b/src/playbook/Executables/AtlasModules/Scripts/Modules/Scripts/Scripts.psm1
@@ -5,113 +5,118 @@
 # Backup Atlas Services and Drivers
 $windir = $([Environment]::GetFolderPath('Windows'))
 function Backup-AtlasServices {
-$filePath = "$([Environment]::GetFolderPath('Windows'))\AtlasModules\Other\atlasServices.reg"
-if (Test-Path $FilePath) { exit }
+    $filePath = "$([Environment]::GetFolderPath('Windows'))\AtlasModules\Other\atlasServices.reg"
+    if (Test-Path $FilePath) { exit }
 
-$content = [System.Collections.Generic.List[string]]::new()
-$content.Add("Windows Registry Editor Version 5.00")
-Get-ChildItem "HKLM:\SYSTEM\CurrentControlSet\Services" | ForEach-Object {
-	try {
-		$values = Get-ItemProperty -Path $_.PSPath -Name 'Start', 'Description' -EA Stop
-		if ($values.Description -notmatch 'Windows Defender') {
-			$content.Add("`n[$($_.Name)]")
-			$content.Add('"Start"=dword:0000000' + $values.Start)	
-		} else {
-			Write-Output "Excluding $($_.Name)..."
-		}
-	} catch {}
-}
+    $content = [System.Collections.Generic.List[string]]::new()
+    $content.Add("Windows Registry Editor Version 5.00")
+    Get-ChildItem "HKLM:\SYSTEM\CurrentControlSet\Services" | ForEach-Object {
+        try {
+            $values = Get-ItemProperty -Path $_.PSPath -Name 'Start', 'Description' -EA Stop
+            if ($values.Description -notmatch 'Windows Defender') {
+                $content.Add("`n[$($_.Name)]")
+                $content.Add('"Start"=dword:0000000' + $values.Start)
+            }
+            else {
+                Write-Output "Excluding $($_.Name)..."
+            }
+        }
+        catch {}
+    }
 
-# Set-Content can only do UTF8 with BOM, which doesn't work with reg.exe
-[System.IO.File]::WriteAllLines($FilePath, $content, (New-Object System.Text.UTF8Encoding $false))
+    # Set-Content can only do UTF8 with BOM, which doesn't work with reg.exe
+    [System.IO.File]::WriteAllLines($FilePath, $content, (New-Object System.Text.UTF8Encoding $false))
 }
 
 # Modify Client.CBS components
 function Update-ClientCBS {
     # --------------------------------------------------------------
-# Remove ads from the 'Accounts' page in Immersive Control Panel
-# --------------------------------------------------------------
+    # Remove ads from the 'Accounts' page in Immersive Control Panel
+    # --------------------------------------------------------------
 
-# Find feature/velocity IDs to disable for the 'Accounts' page
-# After disabling each one, there's a 'Microsoft account' page that appears (ms-settings:account)
-# It can be hidden by using SettingsPageVisibility
+    # Find feature/velocity IDs to disable for the 'Accounts' page
+    # After disabling each one, there's a 'Microsoft account' page that appears (ms-settings:account)
+    # It can be hidden by using SettingsPageVisibility
 
-# Variables
-$windir = [Environment]::GetFolderPath('Windows')
-$settingsExtensions = (Get-ChildItem "$windir\SystemApps" -Recurse).FullName | Where-Object { $_ -like '*wsxpacks\Account\SettingsExtensions.json*' }
-$arm = ((Get-CimInstance -Class Win32_ComputerSystem).SystemType -match 'ARM64') -or ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64')
-if ($settingsExtensions.Count -eq 0) {
-    Write-Output "Settings extensions ($settingsExtensions) not found."
-    Write-Output "User is likely on Windows 10, nothing to do. Exiting..."
-    exit
-}
+    # Variables
+    $windir = [Environment]::GetFolderPath('Windows')
+    $settingsExtensions = (Get-ChildItem "$windir\SystemApps" -Recurse).FullName | Where-Object { $_ -like '*wsxpacks\Account\SettingsExtensions.json*' }
+    $arm = ((Get-CimInstance -Class Win32_ComputerSystem).SystemType -match 'ARM64') -or ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64')
+    if ($settingsExtensions.Count -eq 0) {
+        Write-Output "Settings extensions ($settingsExtensions) not found."
+        Write-Output "User is likely on Windows 10, nothing to do. Exiting..."
+        exit
+    }
 
-# Finds velocity IDs listed in 'Accounts' wsxpack
-function Find-VelocityID($Node) {
-    $ids = @()
-    if ($Node -is [PSCustomObject]) {
-        # If the node is a PSObject, go through through its properties
-        foreach ($property in $Node.PSObject.Properties) {
-            if ($property.Name -eq 'velocityKey' -and $property.Value.id) {
-                $ids += $property.Value.id
+    # Finds velocity IDs listed in 'Accounts' wsxpack
+    function Find-VelocityID($Node) {
+        $ids = @()
+        if ($Node -is [PSCustomObject]) {
+            # If the node is a PSObject, go through through its properties
+            foreach ($property in $Node.PSObject.Properties) {
+                if ($property.Name -eq 'velocityKey' -and $property.Value.id) {
+                    $ids += $property.Value.id
+                }
+                Find-VelocityID -Node $property.Value
             }
-            Find-VelocityID -Node $property.Value
         }
-    } elseif ($Node -is [Array]) {
-        # If the node is an array, go through its elements
-        foreach ($element in $Node) {
-            Find-VelocityID -Node $element
+        elseif ($Node -is [Array]) {
+            # If the node is an array, go through its elements
+            foreach ($element in $Node) {
+                Find-VelocityID -Node $element
+            }
         }
+
+        return $ids
+    }
+    $ids = @()
+    foreach ($settingsJson in $settingsExtensions) {
+        $ids += Find-VelocityID -Node $(Get-Content -Path $settingsJson | ConvertFrom-Json)
     }
 
-    return $ids
-}
-$ids = @()
-foreach ($settingsJson in $settingsExtensions) {
-    $ids += Find-VelocityID -Node $(Get-Content -Path $settingsJson | ConvertFrom-Json)
-}
-
-# No IDs check
-if ($ids.Count -le 0) {
-    Write-Output "No velocity IDs were found. Exiting."
-    exit 1
-}
-
-# Hide 'Microsoft account' page in Settings that appears
-# Not set in the actual YAML in case no velocity IDs were found
-# If the velocity IDs aren't set, then the account page disappears
-& "$windir\AtlasModules\Scripts\settingsPages.cmd" /hide account
-
-# Extract ViVeTool https://github.com/thebookisclosed/ViVe
-# Not done in PowerShell as it's too complicated, it's just easiest to use the actual tool
-$viveZip = Get-ChildItem "ViVeTool-*.zip" -Name
-if ($arm) {
-    $viveZip = $viveZip | Where-Object { $_ -match '-ARM64CLR' }
-} else {
-    $viveZip = $viveZip | Where-Object { $_ -notmatch '-ARM64CLR' }
-}
-
-# Extract & setup ViVeTool
-if ($viveZip) {
-    $viveFolder = Join-Path -Path (Get-Location) -ChildPath "vivetool"
-    if (!(Test-Path -Path $viveFolder)) {
-        New-Item -ItemType Directory -Path $viveFolder | Out-Null
+    # No IDs check
+    if ($ids.Count -le 0) {
+        Write-Output "No velocity IDs were found. Exiting."
+        exit 1
     }
-    Expand-Archive -Path $viveZip -DestinationPath $viveFolder -Force
-} else {
-    throw "ViVeTool not found!"
-}
-$env:PATH += ";$viveFolder"
-if (!(Get-Command 'vivetool' -EA 0)) {
-    throw "ViVeTool EXE not found in ZIP!"
-}
 
-# Disable feature IDs
-# Applies next reboot
-foreach ($id in $($ids | Sort-Object -Unique)) {
-    Write-Output "Disabling feature ID $id..."
-    ViVeTool.exe /disable /id:$id | Out-Null
-}
+    # Hide 'Microsoft account' page in Settings that appears
+    # Not set in the actual YAML in case no velocity IDs were found
+    # If the velocity IDs aren't set, then the account page disappears
+    & "$windir\AtlasModules\Scripts\settingsPages.cmd" /hide account
+
+    # Extract ViVeTool https://github.com/thebookisclosed/ViVe
+    # Not done in PowerShell as it's too complicated, it's just easiest to use the actual tool
+    $viveZip = Get-ChildItem "ViVeTool-*.zip" -Name
+    if ($arm) {
+        $viveZip = $viveZip | Where-Object { $_ -match '-ARM64CLR' }
+    }
+    else {
+        $viveZip = $viveZip | Where-Object { $_ -notmatch '-ARM64CLR' }
+    }
+
+    # Extract & setup ViVeTool
+    if ($viveZip) {
+        $viveFolder = Join-Path -Path (Get-Location) -ChildPath "vivetool"
+        if (!(Test-Path -Path $viveFolder)) {
+            New-Item -ItemType Directory -Path $viveFolder | Out-Null
+        }
+        Expand-Archive -Path $viveZip -DestinationPath $viveFolder -Force
+    }
+    else {
+        throw "ViVeTool not found!"
+    }
+    $env:PATH += ";$viveFolder"
+    if (!(Get-Command 'vivetool' -EA 0)) {
+        throw "ViVeTool EXE not found in ZIP!"
+    }
+
+    # Disable feature IDs
+    # Applies next reboot
+    foreach ($id in $($ids | Sort-Object -Unique)) {
+        Write-Output "Disabling feature ID $id..."
+        ViVeTool.exe /disable /id:$id | Out-Null
+    }
 }
 
 # Disable Core Isolation (VBS)
@@ -121,35 +126,52 @@ function Disable-CoreIsolation {
 
 # Disable Unneeded Devices
 function Disable-Devices {
+    # Disable unneeded network adapter protocol bindings
     Disable-NetAdapterBinding -Name "*" -ComponentID ms_msclient, ms_server, ms_lldp, ms_lltdio, ms_rspndr
-    # Disable PnP (plug and play) devices
-    $devices = @(
-    	"AMD PSP",
-    	"AMD SMBus",
-    	"Base System Device",
-    	"Composite Bus Enumerator",
-    	"Direct memory access controller"
-    	"High precision event timer",
-    	"Intel Management Engine",
-    	"Intel SMBus",
-    	"Legacy device",
-    	"Microsoft Kernel Debug Network Adapter",
-    	"Motherboard resources",
-    	"Numeric Data Processor",
-    	"PCI Data Acquisition and Signal Processing Controller",
-    	"PCI Encryption/Decryption Controller",
-    	"PCI Memory Controller",
-    	"PCI Simple Communications Controller",
-    	"PCI standard RAM Controller",
-    	"SM Bus Controller",
-    	"System CMOS/real time clock",
-    	"System Speaker",
-    	"System Timer"
-    )
-    
-    # No errors as some devices may not have an option to be disabled
-    Get-PnpDevice -FriendlyName $devices -ErrorAction Ignore | Disable-PnpDevice -Confirm:$false -ErrorAction Ignore
 
+    # Disable PnP (plug and play) devices
+    # This is a questionable tweak
+    # It disables core Plug and Play / ACPI / PCI system devices that Windows relies on to correctly understand and manage the hardware.
+    $devicePatterns = @(
+        "ROOT\KDNIC\*",                             # Microsoft Kernel Debug Network Adapter
+        "ROOT\COMPOSITEBUS\*",                      # Composite Bus Enumerator
+        "ACPI\PNP0103\*",                           # High precision event timer
+        "ACPI\PNP0B00\*",                           # System CMOS/real time clock
+        "ACPI\PNP0800\*",                           # System Speaker
+        "ACPI\PNP0100\*",                           # System Timer
+        "ACPI\PNP0200\*",                           # Direct memory access controller
+        "ACPI\PNP0C02\*",                           # Motherboard resources (multiple instances)
+        "ACPI\INT0800\*",                           # Legacy device (Intel)
+        "ACPI\PNP0C04\*"                            # Numeric Data Processor
+    )
+
+    $deviceNames = @(
+        "AMD PSP*",                                 # AMD
+        "AMD SMBus",                                # AMD
+        "Intel*Management Engine*",                 # Intel
+        "Intel*SMBus",								# Intel
+        "Base System Device",						# Intel
+        "PCI Data Acquisition and Signal Processing Controller", # Intel
+        "PCI Encryption/Decryption Controller",				     # Intel
+        "PCI Memory Controller",                                 # Intel
+        "PCI Simple Communications Controller",                  # Intel
+        "PCI standard RAM Controller",                           # Intel
+        "SM Bus Controller"                                      # Intel
+    )
+
+    # Disable devices by InstanceId pattern
+    # No errors as some devices may not have an option to be disabled
+    foreach ($pattern in $devicePatterns) {
+        Get-PnpDevice | Where-Object { $_.InstanceId -like $pattern } |
+        Disable-PnpDevice -Confirm:$false -ErrorAction Ignore
+    }
+
+    # Disable devices by FriendlyName
+    # No errors as some devices may not have an option to be disabled
+    foreach ($name in $deviceNames) {
+        Get-PnpDevice | Where-Object { $_.FriendlyName -like $name } |
+        Disable-PnpDevice -Confirm:$false -ErrorAction Ignore
+    }
 }
 
 # Set File Associations for Web Browsers and Other Apps
@@ -160,7 +182,7 @@ function Set-FileAssociations {
 
     # Uninstall Edge (if applicable)
     Start-Process -FilePath ".\fileAssoc.cmd" -NoNewWindow -Wait
-    
+
     # Set default browser
     if ($Browser -in @("Brave", "LibreWolf", "Firefox", "Google Chrome")) {
         Start-Process -FilePath ".\fileAssoc.cmd" -ArgumentList "`"$Browser`"" -NoNewWindow -Wait
@@ -176,7 +198,7 @@ function Disable-Mitigations {
 function Optimize-PowerShellStartup {
     # speeds up powershell startup time by 10x
     $env:path = "$([Runtime.InteropServices.RuntimeEnvironment]::GetRuntimeDirectory());" + $env:path
-    [AppDomain]::CurrentDomain.GetAssemblies().Location | ? {$_} | % {
+    [AppDomain]::CurrentDomain.GetAssemblies().Location | ? { $_ } | % {
         Write-Host "NGENing: $(Split-Path $_ -Leaf)" -ForegroundColor Yellow
         ngen install $_ | Out-Null
     }
@@ -186,22 +208,22 @@ function Optimize-PowerShellStartup {
 function Set-ProfilePictures {
     Add-Type -AssemblyName System.Drawing
     $img = [System.Drawing.Image]::FromFile((Get-Item '.\user.png'))
-    
+
     $resolutions = @{
-        "user.png" = 448
-        "user.bmp" = 448
-        "guest.png" = 448
-        "guest.bmp" = 448
+        "user.png"     = 448
+        "user.bmp"     = 448
+        "guest.png"    = 448
+        "guest.bmp"    = 448
         "user-192.png" = 192
-        "user-48.png" = 48
-        "user-40.png" = 40
-        "user-32.png" = 32
+        "user-48.png"  = 48
+        "user-40.png"  = 40
+        "user-32.png"  = 32
     }
-    
+
     # Set default profile pictures
     foreach ($image in $resolutions.Keys) {
         $resolution = $resolutions[$image]
-    
+
         $a = New-Object System.Drawing.Bitmap($resolution, $resolution)
         $graph = [System.Drawing.Graphics]::FromImage($a)
         $graph.DrawImage($img, 0, 0, $resolution, $resolution)

--- a/src/playbook/Executables/DISABLEPNP.ps1
+++ b/src/playbook/Executables/DISABLEPNP.ps1
@@ -1,27 +1,44 @@
 # Disable PnP (plug and play) devices
-$devices = @(
-	"AMD PSP",
-	"AMD SMBus",
-	"Base System Device",
-	"Composite Bus Enumerator",
-	"Direct memory access controller"
-	"High precision event timer",
-	"Intel Management Engine",
-	"Intel SMBus",
-	"Legacy device",
-	"Microsoft Kernel Debug Network Adapter",
-	"Motherboard resources",
-	"Numeric Data Processor",
-	"PCI Data Acquisition and Signal Processing Controller",
-	"PCI Encryption/Decryption Controller",
-	"PCI Memory Controller",
-	"PCI Simple Communications Controller",
-	"PCI standard RAM Controller",
-	"SM Bus Controller",
-	"System CMOS/real time clock",
-	"System Speaker",
-	"System Timer"
+# This is a questionable tweak
+# It disables core Plug and Play / ACPI / PCI system devices that Windows relies on to correctly understand and manage the hardware.
+
+$devicePatterns = @(
+    "ROOT\KDNIC\*",                             # Microsoft Kernel Debug Network Adapter
+    "ROOT\COMPOSITEBUS\*",                      # Composite Bus Enumerator
+    "ACPI\PNP0103\*",                           # High precision event timer
+    "ACPI\PNP0B00\*",                           # System CMOS/real time clock
+    "ACPI\PNP0800\*",                           # System Speaker
+    "ACPI\PNP0100\*",                           # System Timer
+    "ACPI\PNP0200\*",                           # Direct memory access controller
+    "ACPI\PNP0C02\*",                           # Motherboard resources (multiple instances)
+    "ACPI\INT0800\*",                           # Legacy device (Intel)
+    "ACPI\PNP0C04\*"                            # Numeric Data Processor
 )
 
+$deviceNames = @(
+    "AMD PSP*",                                 # AMD
+    "AMD SMBus",                                # AMD
+    "Intel*Management Engine*",                 # Intel
+    "Intel*SMBus",								# Intel
+    "Base System Device",						# Intel
+    "PCI Data Acquisition and Signal Processing Controller", # Intel
+    "PCI Encryption/Decryption Controller",				     # Intel
+    "PCI Memory Controller",                                 # Intel
+    "PCI Simple Communications Controller",                  # Intel
+    "PCI standard RAM Controller",                           # Intel
+    "SM Bus Controller"                                      # Intel
+)
+
+# Disable devices by InstanceId pattern
 # No errors as some devices may not have an option to be disabled
-Get-PnpDevice -FriendlyName $devices -ErrorAction Ignore | Disable-PnpDevice -Confirm:$false -ErrorAction Ignore
+foreach ($pattern in $devicePatterns) {
+    Get-PnpDevice | Where-Object { $_.InstanceId -like $pattern } |
+    Disable-PnpDevice -Confirm:$false -ErrorAction Ignore
+}
+
+# Disable devices by FriendlyName
+# No errors as some devices may not have an option to be disabled
+foreach ($name in $deviceNames) {
+    Get-PnpDevice | Where-Object { $_.FriendlyName -like $name } |
+    Disable-PnpDevice -Confirm:$false -ErrorAction Ignore
+}


### PR DESCRIPTION
### Questions
- [x] Did you test your changes or double-check that they work?
- [x] Did you read and follow the [Atlas Contribution Guidelines](https://docs.atlasos.net/contributions/)?

### Changes:
- Use InstanceId patterns (e.g., ACPI\PNP0103\*) which are universal and language-independent
- Add wildcard support for FriendlyName matching (e.g., "AMD PSP*")
- Process devices individually with foreach loops for better error handling
- Add clarifying comments about the questionable nature of this tweak

### Describe your pull request

  The PnP device disabling feature in `DISABLEPNP.ps1` and `Scripts.psm1` used exact `FriendlyName` matching, which only worked on English Windows installations. This caused the feature to fail silently on non-English systems where device names are localized.

  **Solution:**

  - Use `InstanceId` patterns (e.g., `ACPI\PNP0103\*`, `ROOT\KDNIC\*`) which are universal and language-independent
  - Add wildcard support for `FriendlyName` matching (e.g., `"AMD PSP*"`, `"Intel*Management Engine*"`)

  **Why this matters:**

  The previous implementation would not disable any devices on non-English Windows installations (French, German, Spanish, etc.) because device names like "Composite Bus Enumerator" become "Énumérateur de bus composite" in French, "Composite-Busenumerator" in German, etc.

  Using `InstanceId` patterns ensures the tweak works consistently across all language installations, since ACPI/PCI identifiers are standardized.

Note: VSCode did automatically format scripts.psm1 😅