### PR TITLE
Fix new-user first-login tweak context and script prep

### DIFF
--- a/src/playbook/Configuration/tweaks/misc/add-newUser-script.yml
+++ b/src/playbook/Configuration/tweaks/misc/add-newUser-script.yml
@@ -6,5 +6,5 @@ actions:
     path: 'HKU\AME_UserHive_Default\SOFTWARE\Microsoft\Windows\CurrentVersion\RunOnce'
     value: 'RunScript'
     data: |
-      powershell -EP Bypass -NoP & """$([Environment]::GetFolderPath('Windows'))\AtlasModules\Scripts\newUsers.ps1"""
+      powershell -EP RemoteSigned -NoP & """$([Environment]::GetFolderPath('Windows'))\AtlasModules\Scripts\newUsers.ps1"""
     type: REG_SZ

--- a/src/playbook/Executables/AtlasDesktop/3. General Configuration/File Sharing/Network Navigation Pane/Disable Network Navigation Pane (default).cmd
+++ b/src/playbook/Executables/AtlasDesktop/3. General Configuration/File Sharing/Network Navigation Pane/Disable Network Navigation Pane (default).cmd
@@ -3,19 +3,9 @@ set "settingName=NetworkNavigationPane"
 set "stateValue=0"
 set "scriptPath=%~f0"
 
-set "___args="%~f0" %*"
-fltmc > nul 2>&1 || (
-    echo Administrator privileges are required.
-    powershell -c "Start-Process -Verb RunAs -FilePath 'cmd' -ArgumentList """/c $env:___args"""" 2> nul || (
-        echo You must run this script as admin.
-        if "%*"=="" pause
-        exit /b 1
-    )
-    exit /b
-)
-
-reg add "HKLM\SOFTWARE\AtlasOS\Services\%settingName%" /v state /t REG_DWORD /d %stateValue% /f > nul
-reg add "HKLM\SOFTWARE\AtlasOS\Services\%settingName%" /v path /t REG_SZ /d "%scriptPath%" /f > nul
+set "scriptArgs=%*"
+call "%windir%\AtlasModules\Scripts\prepareSetting.cmd" "%settingName%" "%stateValue%" "%scriptPath%" "%scriptArgs%"
+if errorlevel 1 exit /b
 
 
 reg add "HKCU\SOFTWARE\Classes\CLSID\{F02C1A0D-BE21-4350-88B0-7367FC96EF3C}" /v "System.IsPinnedToNameSpaceTree" /t REG_DWORD /d 0 /f > nul

--- a/src/playbook/Executables/AtlasDesktop/4. Interface Tweaks/Context Menus/Windows 11/Old Context Menu (default).cmd
+++ b/src/playbook/Executables/AtlasDesktop/4. Interface Tweaks/Context Menus/Windows 11/Old Context Menu (default).cmd
@@ -5,20 +5,9 @@ set "settingName=OldContextMenu"
 set "stateValue=0"
 set "scriptPath=%~f0"
 
-set "___args="%~f0" %*"
-fltmc > nul 2>&1 || (
-    echo Administrator privileges are required.
-    powershell -c "Start-Process -Verb RunAs -FilePath 'cmd' -ArgumentList """/c $env:___args"""" 2> nul || (
-        echo You must run this script as admin.
-        if "%*"=="" pause
-        exit /b 1
-    )
-    exit /b
-)
-
-:: Update Registry (State and Path)
-reg add "HKLM\SOFTWARE\AtlasOS\Services\%settingName%" /v state /t REG_DWORD /d %stateValue% /f > nul
-reg add "HKLM\SOFTWARE\AtlasOS\Services\%settingName%" /v path /t REG_SZ /d "%scriptPath%" /f > nul
+set "scriptArgs=%*"
+call "%windir%\AtlasModules\Scripts\prepareSetting.cmd" "%settingName%" "%stateValue%" "%scriptPath%" "%scriptArgs%"
+if errorlevel 1 exit /b
 
 :: End of state and path update
 

--- a/src/playbook/Executables/AtlasDesktop/4. Interface Tweaks/File Explorer Customization/Automatic Folder Discovery/Disable Automatic Folder Discovery (default).cmd
+++ b/src/playbook/Executables/AtlasDesktop/4. Interface Tweaks/File Explorer Customization/Automatic Folder Discovery/Disable Automatic Folder Discovery (default).cmd
@@ -5,24 +5,13 @@ set "settingName=AutomaticFolderDiscovery"
 set "stateValue=0"
 set "scriptPath=%~f0"
 
-set "___args="%~f0" %*"
-fltmc > nul 2>&1 || (
-    echo Administrator privileges are required.
-    powershell -c "Start-Process -Verb RunAs -FilePath 'cmd' -ArgumentList """/c $env:___args"""" 2> nul || (
-        echo You must run this script as admin.
-        if "%*"=="" pause
-        exit /b 1
-    )
-    exit /b
-)
-
-:: Update Registry (State and Path)
-reg add "HKLM\SOFTWARE\AtlasOS\Services\%settingName%" /v state /t REG_DWORD /d %stateValue% /f > nul
-reg add "HKLM\SOFTWARE\AtlasOS\Services\%settingName%" /v path /t REG_SZ /d "%scriptPath%" /f > nul
+set "scriptArgs=%*"
+call "%windir%\AtlasModules\Scripts\prepareSetting.cmd" "%settingName%" "%stateValue%" "%scriptPath%" "%scriptArgs%"
+if errorlevel 1 exit /b
 
 :: End of state and path update
-reg delete "HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\Shell\Bags" /f
-reg add "HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\Shell\Bags\AllFolders\Shell" /v "FolderType" /t REG_SZ /d "NotSpecified" /f
+reg delete "HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\Shell\Bags" /f > nul 2>&1
+reg add "HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\Shell\Bags\AllFolders\Shell" /v "FolderType" /t REG_SZ /d "NotSpecified" /f > nul
 
 if "%~1" == "/justcontext" exit /b
 if "%~1"=="/silent" exit /b

--- a/src/playbook/Executables/AtlasDesktop/4. Interface Tweaks/File Explorer Customization/Gallery/Disable Gallery (default).cmd
+++ b/src/playbook/Executables/AtlasDesktop/4. Interface Tweaks/File Explorer Customization/Gallery/Disable Gallery (default).cmd
@@ -5,20 +5,9 @@ set "settingName=Gallery"
 set "stateValue=0"
 set "scriptPath=%~f0"
 
-set "___args="%~f0" %*"
-fltmc > nul 2>&1 || (
-    echo Administrator privileges are required.
-    powershell -c "Start-Process -Verb RunAs -FilePath 'cmd' -ArgumentList """/c $env:___args"""" 2> nul || (
-        echo You must run this script as admin.
-        if "%*"=="" pause
-        exit /b 1
-    )
-    exit /b
-)
-
-:: Update Registry (State and Path)
-reg add "HKLM\SOFTWARE\AtlasOS\Services\%settingName%" /v state /t REG_DWORD /d %stateValue% /f > nul
-reg add "HKLM\SOFTWARE\AtlasOS\Services\%settingName%" /v path /t REG_SZ /d "%scriptPath%" /f > nul
+set "scriptArgs=%*"
+call "%windir%\AtlasModules\Scripts\prepareSetting.cmd" "%settingName%" "%stateValue%" "%scriptPath%" "%scriptArgs%"
+if errorlevel 1 exit /b
 
 :: End of state and path update
 

--- a/src/playbook/Executables/AtlasDesktop/4. Interface Tweaks/Visual Effects (Animations)/Atlas Visual Effects (default).cmd
+++ b/src/playbook/Executables/AtlasDesktop/4. Interface Tweaks/Visual Effects (Animations)/Atlas Visual Effects (default).cmd
@@ -5,20 +5,9 @@ set "settingName=Animation"
 set "stateValue=0"
 set "scriptPath=%~f0"
 
-set "___args="%~f0" %*"
-fltmc > nul 2>&1 || (
-    echo Administrator privileges are required.
-    powershell -c "Start-Process -Verb RunAs -FilePath 'cmd' -ArgumentList """/c $env:___args"""" 2> nul || (
-        echo You must run this script as admin.
-        if "%*"=="" pause
-        exit /b 1
-    )
-    exit /b
-)
-
-:: Update Registry (State and Path)
-reg add "HKLM\SOFTWARE\AtlasOS\Services\%settingName%" /v state /t REG_DWORD /d %stateValue% /f > nul
-reg add "HKLM\SOFTWARE\AtlasOS\Services\%settingName%" /v path /t REG_SZ /d "%scriptPath%" /f > nul
+set "scriptArgs=%*"
+call "%windir%\AtlasModules\Scripts\prepareSetting.cmd" "%settingName%" "%stateValue%" "%scriptPath%" "%scriptArgs%"
+if errorlevel 1 exit /b
 
 :: End of state and path update
 

--- a/src/playbook/Executables/AtlasModules/Scripts/Modules/AllRegistryUsers/AllRegistryUsers.psm1
+++ b/src/playbook/Executables/AtlasModules/Scripts/Modules/AllRegistryUsers/AllRegistryUsers.psm1
@@ -6,13 +6,13 @@ function Get-RegUserPaths {
 
     $regPattern = 'Volatile Environment|AME_UserHive_'
     if ($NoDefault) {$regPattern = "$regPattern[1-9].*"}
-    $initPaths = Get-ChildItem -Path "Registry::HKU" | Where-Object { $_.Name -match "S-[0-9-]+(?!.*_)|$regPattern" }
+    $initPaths = Get-ChildItem -Path "Registry::HKU" -ErrorAction SilentlyContinue | Where-Object { $_.Name -match "S-[0-9-]+(?!.*_)|$regPattern" }
 
     # If the 'Volatile Environment' key exists, that means it is a proper user. Built in accounts/SIDs don't have this key
     $paths = @()
     if (!$DontCheckEnv) {
         foreach ($userKey in $initPaths) {
-            if ((Get-ChildItem -Path $userKey.PsPath | Where-Object { $_ -match $regPattern }).Count -ne 0) {
+            if ((Get-ChildItem -Path $userKey.PsPath -ErrorAction SilentlyContinue | Where-Object { $_.Name -match $regPattern }).Count -ne 0) {
                 $paths += $userKey
             }
         }

--- a/src/playbook/Executables/AtlasModules/Scripts/RunAsTI.cmd
+++ b/src/playbook/Executables/AtlasModules/Scripts/RunAsTI.cmd
@@ -59,7 +59,10 @@ pause > nul
 goto RunAsTI-Elevate
 
 :RunAsTI
-echo Administrator privileges are required.
+set "_runAsTiArgs=%*"
+set "RunAsTI_WindowStyle=Normal"
+echo %_runAsTiArgs% | findstr /i /c:"/silent" /c:"-silent" /c:"/quiet" > nul 2>&1 && set "RunAsTI_WindowStyle=Hidden"
+if /I not "%RunAsTI_WindowStyle%"=="Hidden" echo Administrator privileges are required.
 
 set "0=%~f0"
 set "1=%*"
@@ -90,7 +93,7 @@ function RunAsTI ($cmd,$arg) { $id='RunAsTI'; $key="Registry::HKU\$(((whoami /us
  function M ($1,$2,$3) {$M."G`etMethod"($1,[type[]]$2).invoke(0,$3)}; $H=@(); $Z,(4*$Z+16)|% {$H += M "AllocHG`lobal" $I $_}
  M "WriteInt`Ptr" ($P,$P) ($H[0],$As.Handle); $A1.f1=131072; $A1.f2=$Z; $A1.f3=$H[0]; $A2.f1=1; $A2.f2=1; $A2.f3=1; $A2.f4=1
  $A2.f6=$A1; $A3.f1=10*$Z+32; $A4.f1=$A3; $A4.f2=$H[1]; M "StructureTo`Ptr" ($D[2],$P,[boolean]) (($A2 -as $D[2]),$A4.f2,$false)
- $Run=@($null, "powershell -win 1 -nop -c iex `$env:R; # $id", 0, 0, 0, 0x0E080600, 0, $null, ($A4 -as $T[4]), ($A5 -as $T[5]))
+ $Run=@($null, "powershell -windowstyle $env:RunAsTI_WindowStyle -nop -c iex `$env:R; # $id", 0, 0, 0, 0x0E080600, 0, $null, ($A4 -as $T[4]), ($A5 -as $T[5]))
  F 'CreateProcess' $Run; return}; $env:R=''; rp $key $id -force; $priv=[diagnostics.process]."GetM`ember"('SetPrivilege',42)[0]
  'SeSecurityPrivilege','SeTakeOwnershipPrivilege','SeBackupPrivilege','SeRestorePrivilege' |% {$priv.Invoke($null, @("$_",2))}
  $HKU=[uintptr][uint32]2147483651; $NT='S-1-5-18'; $reg=($HKU,$NT,8,2,($HKU -as $D[9])); F 'RegOpenKeyEx' $reg; $LNK=$reg[4]
@@ -104,7 +107,7 @@ function RunAsTI ($cmd,$arg) { $id='RunAsTI'; $key="Registry::HKU\$(((whoami /us
  if ($11bug) {$w=0; do {if($w-gt40){break}; sleep -mi 250;$w++} until (Q); [Microsoft.VisualBasic.Interaction]::AppActivate($(Q))}
  if ($11bug) {[Windows.Forms.SendKeys]::SendWait($path)}; do {sleep 7} while(Q); L '.Default' $LNK 'Interactive User'
 '@; $V='';'cmd','arg','id','key'|%{$V+="`n`$$_='$($(gv $_ -val)-replace"'","''")';"}; sp $key $id $($V,$code) -type 7 -force -ea 0
- start powershell -args "-win 1 -nop -c `n$V `$env:R=(gi `$key -ea 0).getvalue(`$id)-join''; iex `$env:R" -verb runas
+ start powershell -args "-windowstyle $env:RunAsTI_WindowStyle -nop -c `n$V `$env:R=(gi `$key -ea 0).getvalue(`$id)-join''; iex `$env:R" -verb runas
 } #:RunAsTI lean & mean snippet by AveYo, 2023.07.06
 
 Try {

--- a/src/playbook/Executables/AtlasModules/Scripts/newUsers.cmd
+++ b/src/playbook/Executables/AtlasModules/Scripts/newUsers.cmd
@@ -12,6 +12,6 @@ whoami /user | find /i "S-1-5-18" > nul 2>&1 || (
     exit /b
 )
 
-powershell -ExecutionPolicy Bypass -NoProfile -File "%script%"
+powershell -ExecutionPolicy RemoteSigned -NoProfile -File "%script%"
 
 pause

--- a/src/playbook/Executables/AtlasModules/Scripts/newUsers.ps1
+++ b/src/playbook/Executables/AtlasModules/Scripts/newUsers.ps1
@@ -1,7 +1,3 @@
-if (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) { 
-  Start-Process powershell.exe "-NoProfile -ExecutionPolicy Bypass -File `"$PSCommandPath`"" -Verb RunAs; exit 
-}
-
 $windir = [Environment]::GetFolderPath('Windows')
 & "$windir\AtlasModules\initPowerShell.ps1"
 $atlasDesktop = "$windir\AtlasDesktop"
@@ -20,36 +16,62 @@ Write-Host $title -ForegroundColor Yellow
 Write-Host $('-' * ($title.length + 3)) -ForegroundColor Yellow
 Write-Host "You'll be logged out in 10 to 20 seconds, and once you login again, your new account will be ready for use."
 
-# Disable Windows 11 context menu & 'Gallery' in File Explorer
-if ([System.Environment]::OSVersion.Version.Build -ge 22000) {
-    & "$atlasDesktop\4. Interface Tweaks\Context Menus\Windows 11\Old Context Menu (default).cmd" /silent
-    & "$atlasDesktop\4. Interface Tweaks\File Explorer Customization\Gallery\Disable Gallery (default).cmd" /silent
+$env:ATLAS_USER_CONTEXT = "1"
+try {
+    # Disable Windows 11 context menu & 'Gallery' in File Explorer
+    if ([System.Environment]::OSVersion.Version.Build -ge 22000) {
+        & "$atlasDesktop\4. Interface Tweaks\Context Menus\Windows 11\Old Context Menu (default).cmd" /silent
+        & "$atlasDesktop\4. Interface Tweaks\File Explorer Customization\Gallery\Disable Gallery (default).cmd" /silent
 
-    # Set ThemeMRU (recent themes)
-    Set-Theme -Path "$([Environment]::GetFolderPath('Windows'))\Resources\Themes\atlas-v0.5.x-dark.theme"
-    Set-ThemeMRU | Out-Null
+        # Set ThemeMRU (recent themes)
+        Set-Theme -Path "$([Environment]::GetFolderPath('Windows'))\Resources\Themes\atlas-v0.5.x-dark.theme"
+        Set-ThemeMRU | Out-Null
+    }
+
+    # Set lockscreen wallpaper
+    try {
+        Set-LockscreenImage
+    }
+    catch {
+        Write-Warning "Failed to set lockscreen image: $($_.Exception.Message)"
+    }
+
+    # Disable 'Network' in navigation pane
+    & "$atlasDesktop\3. General Configuration\File Sharing\Network Navigation Pane\Disable Network Navigation Pane (default).cmd" /silent
+
+    # Disable Automatic Folder Discovery
+    & "$atlasDesktop\4. Interface Tweaks\File Explorer Customization\Automatic Folder Discovery\Disable Automatic Folder Discovery (default).cmd" /silent
+
+    # Set visual effects
+    & "$atlasDesktop\4. Interface Tweaks\Visual Effects (Animations)\Atlas Visual Effects (default).cmd" /silent
+}
+finally {
+    Remove-Item "Env:\ATLAS_USER_CONTEXT" -ErrorAction SilentlyContinue
 }
 
-# Set lockscreen wallpaper
-Set-LockscreenImage
+# Set taskbar pins
+$browser = $null
+$setupOptionsPath = "HKLM:\SOFTWARE\AtlasOS\SetupOptions"
+$allowedBrowsers = @("Brave", "Firefox", "LibreWolf", "Google Chrome", "Microsoft Edge")
 
-# Disable 'Network' in navigation pane
-& "$atlasDesktop\3. General Configuration\File Sharing\Network Navigation Pane\Disable Network Navigation Pane (default).cmd" /silent
+try {
+    $browser = Get-ItemPropertyValue -Path $setupOptionsPath -Name "Browser" -ErrorAction Stop
+}
+catch {
+    Write-Warning "Couldn't read browser selection from '$setupOptionsPath'. Falling back to default taskbar pins."
+}
 
-# Disable Automatic Folder Discovery
-& "$atlasDesktop\4. Interface Tweaks\File Explorer Customization\Automatic Folder Discovery\Disable Automatic Folder Discovery (default).cmd" /silent
+if (![string]::IsNullOrWhiteSpace($browser) -and $browser -notin $allowedBrowsers) {
+    Write-Warning "Invalid browser value '$browser' found in '$setupOptionsPath'. Falling back to default taskbar pins."
+    $browser = $null
+}
 
-# Set visual effects
-& "$atlasDesktop\4. Interface Tweaks\Visual Effects (Animations)\Atlas Visual Effects (default).cmd" /silent
+if ([string]::IsNullOrWhiteSpace($browser)) {
+    $browser = $null
+}
 
-# Set taskbar pins 
-$valueName = "Browser"
-$value = Get-ItemProperty -Path "HKLM:\SOFTWARE\AtlasOS\SetupOptions" -Name $valueName -ErrorAction Stop
-$Browser = $value.$valueName
-$Browser
-
-& "$atlasModules\Scripts\taskbarPins.ps1" $Browser
-Set-ItemProperty -Path "HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Search" -Name "SearchboxTaskbarMode" -Value 1
+& "$atlasModules\Scripts\taskbarPins.ps1" $browser
+& reg.exe add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Search" /v "SearchboxTaskbarMode" /t REG_DWORD /d 1 /f *> $null
 
 # Leave
 Start-Sleep 5 

--- a/src/playbook/Executables/AtlasModules/Scripts/prepareSetting.cmd
+++ b/src/playbook/Executables/AtlasModules/Scripts/prepareSetting.cmd
@@ -1,0 +1,30 @@
+@echo off
+setlocal
+
+if "%~3"=="" (
+    echo error: missing required arguments.
+    exit /b 1
+)
+
+set "settingName=%~1"
+set "stateValue=%~2"
+set "scriptPath=%~3"
+set "scriptArgs=%~4"
+
+if /I "%ATLAS_USER_CONTEXT%"=="1" exit /b 0
+
+set "___args="%scriptPath%" %scriptArgs%"
+fltmc > nul 2>&1 || (
+    echo Administrator privileges are required.
+    powershell -c "Start-Process -Verb RunAs -FilePath 'cmd' -ArgumentList """/c $env:___args"""" 2> nul || (
+        echo You must run this script as admin.
+        if "%scriptArgs%"=="" pause
+        exit /b 1
+    )
+    exit /b 1
+)
+
+reg add "HKLM\SOFTWARE\AtlasOS\Services\%settingName%" /v state /t REG_DWORD /d %stateValue% /f > nul || exit /b 1
+reg add "HKLM\SOFTWARE\AtlasOS\Services\%settingName%" /v path /t REG_SZ /d "%scriptPath%" /f > nul || exit /b 1
+
+exit /b 0


### PR DESCRIPTION
### Questions
- [x] Did you test your changes or double-check that they work?
- [x] Did you read and follow the [Atlas Contribution Guidelines](https://docs.atlasos.net/contributions/)?

### Describe your pull request
- ensure first-login/new-user tweaks run in the correct user context instead of elevating into a different profile
- add a shared prepareSetting.cmd helper and update related AtlasDesktop scripts to reuse consistent elevation/state handling
- reduce noisy registry/user enumeration errors and make new-user setup more resilient (including lockscreen failure handling)
