### PR TITLE
Harden installer and wrapper execution paths

### DIFF
--- a/src/playbook/Executables/AtlasDesktop/2. Drivers/Run Update Drivers.cmd
+++ b/src/playbook/Executables/AtlasDesktop/2. Drivers/Run Update Drivers.cmd
@@ -18,7 +18,7 @@ if not exist "%script%" (
     exit /b 1
 )
 
-powershell -ExecutionPolicy Bypass -NoProfile -File "%script%"
+powershell -ExecutionPolicy RemoteSigned -NoProfile -File "%script%"
 
 echo.
 pause > null

--- a/src/playbook/Executables/AtlasModules/Scripts/ScriptWrappers/RemoveEdge.ps1
+++ b/src/playbook/Executables/AtlasModules/Scripts/ScriptWrappers/RemoveEdge.ps1
@@ -38,15 +38,18 @@ param (
     [switch]$NonInteractive
 )
 
+Set-StrictMode -Version 3.0
+
 $version = '1.9.5'
 
 $ProgressPreference = 'SilentlyContinue'
 $sys32 = [Environment]::GetFolderPath('System')
 $windir = [Environment]::GetFolderPath('Windows')
 $env:path = "$windir;$sys32;$sys32\Wbem;$sys32\WindowsPowerShell\v1.0;" + $env:path
-$baseKey = 'HKLM:\SOFTWARE' + $(if ([Environment]::Is64BitOperatingSystem) { '\WOW6432Node' }) + '\Microsoft'
-$msedgeExe = "$([Environment]::GetFolderPath('ProgramFilesx86'))\Microsoft\Edge\Application\msedge.exe"
-$edgeUWP = "$windir\SystemApps\Microsoft.MicrosoftEdge_8wekyb3d8bbwe"
+$msedgeExePaths = @(
+    "$([Environment]::GetFolderPath('ProgramFilesx86'))\Microsoft\Edge\Application\msedge.exe",
+    "$([Environment]::GetFolderPath('ProgramFiles'))\Microsoft\Edge\Application\msedge.exe"
+)
 
 if ($NonInteractive -and (!$UninstallEdge -and !$InstallEdge -and !$InstallWebView)) {
     $NonInteractive = $false
@@ -113,7 +116,13 @@ function DeleteIfExist($Path) {
 
 # True if it's installed
 function EdgeInstalled {
-    Test-Path $msedgeExe
+    foreach ($msedgeExe in $msedgeExePaths) {
+        if (Test-Path $msedgeExe) {
+            return $true
+        }
+    }
+
+    return $false
 }
 
 function KillEdgeProcesses {
@@ -136,6 +145,7 @@ function InstallEdgeChromium {
     $temp = mkdir (Join-Path $([System.IO.Path]::GetTempPath()) $(New-Guid))
     $msi = "$temp\edge.msi"
     $msiLog = "$temp\edgeMsi.log"
+    $link = 'Undefined'
 
     if ([Environment]::Is64BitOperatingSystem) {
         $arm = ((Get-CimInstance -Class Win32_ComputerSystem).SystemType -match 'ARM64') -or ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64')
@@ -155,7 +165,7 @@ function InstallEdgeChromium {
 Error: $_" -Level Critical -Exit -ExitCode 4
         }
 
-        $edgeItem = ($edgeUpdateApi | ? { $_.Product -eq 'Stable' }).Releases |
+        $edgeItem = ($edgeUpdateApi | Where-Object { $_.Product -eq 'Stable' }).Releases |
         Where-Object { $_.Platform -eq 'Windows' -and $_.Architecture -eq $archString } |
         Where-Object { $_.Artifacts.Count -ne 0 } | Select-Object -First 1
 
@@ -163,7 +173,7 @@ Error: $_" -Level Critical -Exit -ExitCode 4
             Write-Status 'Failed to parse EdgeUpdate API! No matching artifacts found.' -Level Critical -Exit
         }
 
-        $hashAlg = $edgeItem.Artifacts.HashAlgorithm | % { if ([string]::IsNullOrEmpty($_)) { 'SHA256' } else { $_ } }
+        $hashAlg = $edgeItem.Artifacts.HashAlgorithm | ForEach-Object { if ([string]::IsNullOrEmpty($_)) { 'SHA256' } else { $_ } }
         foreach ($var in @{
                 link     = $edgeItem.Artifacts.Location
                 hash     = $edgeItem.Artifacts.Hash
@@ -223,7 +233,7 @@ Error: $_" -Level Critical -Exit -ExitCode 6
             Write-Status 'Verified the Microsoft Edge installer!' -Level Success
         }
         else {
-            Write-Status 'Edge installer hash does not match. The installer might be corrupted. Continuing anyways...' -Level Error
+            Write-Status 'Edge installer hash does not match. Refusing to continue with an untrusted installer.' -Level Critical -Exit -ExitCode 10
         }
     }
 
@@ -280,7 +290,7 @@ Please relaunch this script under a regular admin account." -Level Critical -Exi
 else {
     if (!([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)) {
         if ($PSBoundParameters.Count -le 0 -and !$args) {
-            Start-Process cmd "/c PowerShell -NoP -EP Bypass -File `"$PSCommandPath`"" -Verb RunAs
+            Start-Process cmd "/c PowerShell -NoP -EP RemoteSigned -File `"$PSCommandPath`"" -Verb RunAs
             exit
         }
         else {
@@ -293,6 +303,7 @@ $edgeInstalled = EdgeInstalled
 if (!$UninstallEdge -and !$InstallEdge -and !$InstallWebView) {
     $host.UI.RawUI.WindowTitle = "AtlasOS EdgeRemover"
 
+    $continue = $false
     $RemoveEdgeData = $false
     while (!$continue) {
         Clear-Host
@@ -346,31 +357,82 @@ To perform an action, also type its number.
     Clear-Host
 }
 
-# Project originally made by ShadowWhisperer and is licensed under CC0-1.0 License
-# https://github.com/ShadowWhisperer/Remove-MS-Edge
-# https://api.github.com/repos/ShadowWhisperer/Remove-MS-Edge/contents/Batch/Edge.bat
 if ($UninstallEdge) {
-    Write-Status "Uninstalling Edge Chromium..."
-    try {
-        $tempDirectory = Join-Path ([IO.Path]::GetTempPath()) ([IO.Path]::GetRandomFileName())
-        New-Item -ItemType Directory -Path $tempDirectory | Out-Null
+    Write-Status 'Uninstalling Edge Chromium...'
+    KillEdgeProcesses
 
-        & curl.exe -LSs "https://raw.githubusercontent.com/ShadowWhisperer/Remove-MS-Edge/main/Batch/Edge.bat" -o "$tempDirectory\Edge.bat"
-        if (!$?) {
-            Write-Error "Downloading script failed."
-            exit 1
+    $setupCandidates = @()
+    foreach ($root in @(
+            "$([Environment]::GetFolderPath('ProgramFilesx86'))\Microsoft\Edge\Application",
+            "$([Environment]::GetFolderPath('ProgramFiles'))\Microsoft\Edge\Application"
+        )) {
+        if (Test-Path $root) {
+            $setupCandidates += Get-ChildItem -Path $root -Filter 'setup.exe' -Recurse -ErrorAction SilentlyContinue
+        }
+    }
+
+    $setupCandidates = @($setupCandidates | Sort-Object -Property FullName -Unique)
+    if ($setupCandidates.Count -gt 0) {
+        foreach ($setup in $setupCandidates) {
+            Write-Status "Running uninstaller at '$($setup.FullName)'..."
+            $process = Start-Process -FilePath $setup.FullName -ArgumentList '--uninstall --msedge --system-level --verbose-logging --force-uninstall' -WindowStyle Hidden -Wait -PassThru
+            if (($process.ExitCode -eq 0) -or (-not (EdgeInstalled))) {
+                break
+            }
+
+            Write-Status "Edge uninstaller exited with code $($process.ExitCode); trying fallback methods." -Level Info
+        }
+    }
+    elseif (EdgeInstalled) {
+        Write-Status 'Could not locate a local Edge installer to perform uninstallation.' -Level Warning
+    }
+
+    KillEdgeProcesses
+    if (EdgeInstalled) {
+        $legacyRemoved = $false
+        try {
+            $legacyTempDirectory = Join-Path ([IO.Path]::GetTempPath()) ([IO.Path]::GetRandomFileName())
+            New-Item -ItemType Directory -Path $legacyTempDirectory -Force | Out-Null
+            $legacyScript = Join-Path $legacyTempDirectory 'Edge.bat'
+
+            # Project originally made by ShadowWhisperer and licensed under CC0-1.0.
+            # https://github.com/ShadowWhisperer/Remove-MS-Edge
+            Write-Status 'Trying legacy Edge removal fallback...'
+            if ($null -ne (Get-Command curl.exe -ErrorAction SilentlyContinue)) {
+                & curl.exe -LSs "https://raw.githubusercontent.com/ShadowWhisperer/Remove-MS-Edge/main/Batch/Edge.bat" -o "$legacyScript"
+            }
+            else {
+                Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/ShadowWhisperer/Remove-MS-Edge/main/Batch/Edge.bat' -OutFile $legacyScript -UseBasicParsing -ErrorAction Stop
+            }
+
+            if (Test-Path $legacyScript) {
+                Start-Process -FilePath $legacyScript -WindowStyle Hidden -Wait -ArgumentList '-auto' | Out-Null
+                KillEdgeProcesses
+                $legacyRemoved = -not (EdgeInstalled)
+            }
+        }
+        catch {
+            if (EdgeInstalled) {
+                Write-Status "Legacy fallback failed: $($_.Exception.Message)" -Level Warning
+            }
         }
 
-        Start-Process -FilePath "$tempDirectory\Edge.bat" -WindowStyle Hidden -Wait -ArgumentList '-auto'
-        Write-Output "Successfully removed Microsoft Edge..."
-        Write-Output "Press any key to exit"
-        Read-Host
-        exit
+        if ((-not $legacyRemoved) -and (EdgeInstalled)) {
+            if ($KeepAppX -or $NonInteractive) {
+                Write-Status 'Edge binaries were not fully removed. Continuing so playbook cleanup can finish.' -Level Warning
+            }
+            else {
+                Write-Status 'Failed to uninstall Microsoft Edge using all available removal methods.' -Level Critical -Exit -ExitCode 12
+            }
+        }
+        else {
+            Write-Status 'Successfully removed Microsoft Edge.' -Level Success
+        }
     }
-    catch {
-        Write-Warning "An error occurred: $_"
-        return $false
+    else {
+        Write-Status 'Edge is already uninstalled.' -Level Success
     }
+
     Write-Output ""
 }
 

--- a/src/playbook/Executables/AtlasModules/Scripts/ScriptWrappers/UpdateDrivers.ps1
+++ b/src/playbook/Executables/AtlasModules/Scripts/ScriptWrappers/UpdateDrivers.ps1
@@ -1,16 +1,28 @@
 [CmdletBinding()]
 param (
-    [switch]$RestartAfterUpdate
+    [switch]$RestartAfterUpdate,
+    [switch]$Silent
 )
-
-$script:SelectedUpdates = @()
 
 function Test-Admin {
     $currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent()
-    $principal   = New-Object System.Security.Principal.WindowsPrincipal($currentUser)
+    $principal = New-Object System.Security.Principal.WindowsPrincipal($currentUser)
     if (-not $principal.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)) {
         Write-Host "Restarting script with administrator privileges..."
-        Start-Process -FilePath "powershell" -ArgumentList "-ExecutionPolicy Bypass -NoProfile -File `"$PSCommandPath`"" -Verb RunAs
+
+        $arguments = @(
+            "-ExecutionPolicy RemoteSigned",
+            "-NoProfile",
+            "-File `"$PSCommandPath`""
+        )
+        if ($RestartAfterUpdate) {
+            $arguments += "-RestartAfterUpdate"
+        }
+        if ($Silent) {
+            $arguments += "-Silent"
+        }
+
+        Start-Process -FilePath "powershell" -ArgumentList ($arguments -join " ") -Verb RunAs
         exit
     }
 }
@@ -37,89 +49,132 @@ function Show-DriverSelection {
     param (
         [array]$Updates
     )
+
     if ($Updates.Count -eq 0) {
         return @()
     }
-    
+
     Add-Type -AssemblyName PresentationFramework
 
-    $Window = New-Object System.Windows.Window
-    $Window.Title = "Select drivers to install"
-    $Window.Width = 500
-    $Window.Height = 400
-    $Window.WindowStartupLocation = "CenterScreen"
+    $window = New-Object System.Windows.Window
+    $window.Title = "Select drivers to install"
+    $window.Width = 500
+    $window.Height = 400
+    $window.WindowStartupLocation = "CenterScreen"
 
-    $StackPanel = New-Object System.Windows.Controls.StackPanel
+    $stackPanel = New-Object System.Windows.Controls.StackPanel
 
-    $ListBox = New-Object System.Windows.Controls.ListBox
-    $ListBox.SelectionMode = "Extended"
+    $listBox = New-Object System.Windows.Controls.ListBox
+    $listBox.SelectionMode = "Extended"
     foreach ($update in $Updates) {
         $item = New-Object System.Windows.Controls.ListBoxItem
         $item.Content = $update.Title.ToString().Trim()
-        $ListBox.Items.Add($item) | Out-Null
+        $listBox.Items.Add($item) | Out-Null
     }
-    $StackPanel.Children.Add($ListBox) | Out-Null
+    $stackPanel.Children.Add($listBox) | Out-Null
 
-    $OKButton = New-Object System.Windows.Controls.Button
-    $OKButton.Content = "OK"
-    $OKButton.Margin = "10,10,10,10"
-    $OKButton.Add_Click({
-        $Window.Tag = $ListBox.SelectedItems
-        $Window.Close()
-    })
-    $StackPanel.Children.Add($OKButton) | Out-Null
+    $okButton = New-Object System.Windows.Controls.Button
+    $okButton.Content = "OK"
+    $okButton.Margin = "10,10,10,10"
+    $okButton.Add_Click({
+            $window.Tag = $listBox.SelectedItems
+            $window.Close()
+        })
+    $stackPanel.Children.Add($okButton) | Out-Null
 
-    $Window.Content = $StackPanel
-    $Window.ShowDialog() | Out-Null
+    $window.Content = $stackPanel
+    $window.ShowDialog() | Out-Null
 
     $selectedUpdates = @()
-    foreach ($selected in $Window.Tag) {
+    foreach ($selected in $window.Tag) {
         $title = $selected.Content
         $update = $Updates | Where-Object { $_.Title.ToString().Trim() -eq $title }
         if ($update) {
             $selectedUpdates += $update
         }
     }
+
     return $selectedUpdates
 }
 
 function Update-Drivers {
     Write-Host "Checking for driver updates..."
-    $Updates = Get-WUList -MicrosoftUpdate -Category "Drivers"
-    
-    if ($Updates.Count -gt 0) {
-        Write-Host "Available driver updates:"
-        $selection = Show-DriverSelection -Updates $Updates
+    try {
+        $updates = @(Get-WUList -MicrosoftUpdate -Category "Drivers" -ErrorAction Stop)
+    }
+    catch {
+        Write-Error "Failed to query driver updates: $($_.Exception.Message)"
+        return $false
+    }
 
-        $selection = @($selection)
-        
-        if ($selection.Count -gt 0) {
-            Write-Host "Installing selected driver updates..."
-            $selection | Format-Table ComputerName, Status, KB, Size, Title -AutoSize
-            $selection | Get-WUInstall -AcceptAll -IgnoreReboot -Confirm:$false | Out-Null
-            Write-Host "Driver updates installed successfully!"
+    if ($updates.Count -eq 0) {
+        Write-Host "No driver updates found."
+        return $true
+    }
 
-            $restartChoice = Read-Host "Do you want to restart now? (Y/N)"
-            if ($restartChoice -match "^[Yy]$") {
-                Write-Host "Restarting the system in 10 seconds..."
-                Start-Sleep -Seconds 10
-                Restart-Computer -Force
-            }
-        }
-        else {
-            Write-Host "No drivers were selected for update."
-        }
+    Write-Host "Available driver updates:"
+
+    if ($Silent) {
+        Write-Host "Silent mode enabled; selecting all available driver updates."
+        $selection = $updates
     }
     else {
-        Write-Host "No driver updates found."
+        $selection = @(Show-DriverSelection -Updates $updates)
     }
+
+    if ($selection.Count -eq 0) {
+        Write-Host "No drivers were selected for update."
+        return $true
+    }
+
+    Write-Host "Installing selected driver updates..."
+    $selection | Format-Table ComputerName, Status, KB, Size, Title -AutoSize
+
+    try {
+        $selection | Get-WUInstall -AcceptAll -IgnoreReboot -Confirm:$false -ErrorAction Stop | Out-Null
+    }
+    catch {
+        Write-Error "Driver update installation failed: $($_.Exception.Message)"
+        return $false
+    }
+
+    Write-Host "Driver updates installed successfully!"
+
+    if ($RestartAfterUpdate) {
+        Write-Host "RestartAfterUpdate is enabled. Restarting the system in 10 seconds..."
+        Start-Sleep -Seconds 10
+        Restart-Computer -Force
+        return $true
+    }
+
+    if (-not $Silent) {
+        $restartChoice = Read-Host "Do you want to restart now? (Y/N)"
+        if ($restartChoice -match "^[Yy]$") {
+            Write-Host "Restarting the system in 10 seconds..."
+            Start-Sleep -Seconds 10
+            Restart-Computer -Force
+        }
+    }
+
+    return $true
 }
 
-Install-PSWindowsUpdateModule
-Enable-MicrosoftUpdate
-Update-Drivers
+$scriptSucceeded = $false
+try {
+    Install-PSWindowsUpdateModule
+    Enable-MicrosoftUpdate
+    $scriptSucceeded = Update-Drivers
+}
+catch {
+    Write-Error "Driver update process failed: $($_.Exception.Message)"
+    exit 1
+}
 
-if (-not $PSCmdlet.MyInvocation.BoundParameters.ContainsKey('Silent')) {
+if (-not $scriptSucceeded) {
+    exit 1
+}
+
+if (-not $Silent) {
     Write-Host "Press any key to exit..."
     $null = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
 }

--- a/src/playbook/Executables/AtlasModules/Scripts/installToolbox.ps1
+++ b/src/playbook/Executables/AtlasModules/Scripts/installToolbox.ps1
@@ -8,9 +8,12 @@ else {
     try {
         $tempDirectory = Join-Path ([IO.Path]::GetTempPath()) ([IO.Path]::GetRandomFileName())
         New-Item -ItemType Directory -Path $tempDirectory | Out-Null
+        $timeouts = @("--connect-timeout", "10", "--retry", "5", "--retry-delay", "0", "--retry-all-errors")
+        $toolboxDownloadLatest = "https://github.com/Atlas-OS/atlas-toolbox/releases/latest/download/AtlasToolbox-Setup.exe"
 
         Write-Output "Downloading Toolbox..."
-        & curl.exe -LSs "https://github.com/Atlas-OS/atlas-toolbox/releases/latest/download/AtlasToolbox-Setup.exe" -o "$tempDirectory\toolbox.exe"
+        & curl.exe -LSs $toolboxDownloadLatest -o "$tempDirectory\toolbox.exe" $timeouts
+
         if (!$?) {
             Write-Error "Downloading Toolbox failed."
             exit 1

--- a/src/playbook/Executables/AtlasModules/Scripts/packageInstall.ps1
+++ b/src/playbook/Executables/AtlasModules/Scripts/packageInstall.ps1
@@ -12,6 +12,8 @@ param (
 	[switch]$FailMessage
 )
 
+Set-StrictMode -Version 3.0
+
 if (!([Security.Principal.WindowsIdentity]::GetCurrent().User.Value -eq 'S-1-5-18')) {
 	throw "This script must be ran as TrustedInstaller/SYSTEM."
 }
@@ -45,14 +47,13 @@ function Write-BulletPoint($message) {
 function SafeMode {
 	param (
 		[switch]$Enable,
-		[switch]$FailMessage,
 		[array]$FailedPackageList,
 		[string]$FailedPackageListPath = $safeModePackageList
 	)
 
 	if ($Enable) {
 		$bcdeditArgs = '/set {current} safeboot minimal'
-		$shellValue = "explorer.exe,cmd /c RunAsTI powershell -NoP -EP Unrestricted -File `"$PSCommandPath`" -SafeMode"
+		$shellValue = "explorer.exe,cmd /c RunAsTI powershell -NoP -EP RemoteSigned -File `"$PSCommandPath`" -SafeMode"
 
 		if ($FailedPackageList) {
 			Set-Content -Path $FailedPackageListPath -Value $FailedPackageList
@@ -62,7 +63,7 @@ function SafeMode {
 		$shellValue = 'explorer.exe'
 	}
 
-	if ($bcdeditArgs) { Start-Process -FilePath "bcdedit" -ArgumentList $bcdeditArgs -WindowStyle Hidden }
+	if ($bcdeditArgs) { Start-Process -FilePath "bcdedit" -ArgumentList $bcdeditArgs -WindowStyle Hidden -Wait }
 	Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon' -Name Shell -Value $shellValue -Force
 }
 if (
@@ -84,6 +85,8 @@ function Restart {
 }
 
 function Finish($failedPackages) {
+	$failedPackages = @($failedPackages | Where-Object { $_ })
+
 	function GenerateText($text, $dashCount = 84) {
 		$separator = "[ $('-' * $dashCount) ]"
 		$text = "[ $text $(' ' * ($dashCount - $text.Length - 1)) ]"
@@ -106,7 +109,7 @@ $separator
 
 			$failedMsgTitle = 'AtlasFailedComponentMsgBox'
 			$failedMsgArgs = "/c title Finalizing Installation - Atlas & echo Do not close this window. & schtasks /delete /tn `"$failedMsgTitle`" /f > nul & " `
-			+ "PowerShell -NoP -NonI -W Hidden -EP Bypass -C `"& '$PSCommandPath' -FailMessage`""
+			+ "PowerShell -NoP -NonI -W Hidden -EP RemoteSigned -C `"& '$PSCommandPath' -FailMessage`""
 			$failedMsg = @{
 				'TaskName'    = $failedMsgTitle
 				'Settings'    = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries
@@ -178,8 +181,8 @@ if ($UninstallPackages) {
 		Write-Host "[WARN] '$UninstallPackages' matched no installed packages, nothing to do." -ForegroundColor Yellow
 		$script:warningLevel++
 	} else {
-		if ($notMatchedPackages.Count -gt 0) {
-			Write-Host "[WARN] Some packages not found to uninstall: $notMatchedPackages" -ForegroundColor Yellow
+		if ($notInstalledPackages.Count -gt 0) {
+			Write-Host "[WARN] Some packages not found to uninstall: $notInstalledPackages" -ForegroundColor Yellow
 			$script:warningLevel++
 		}
 
@@ -236,7 +239,7 @@ if ($SafeMode) {
 		}
 	}
 
-	$matchedPackages = Get-Content $safeModePackageList
+	$matchedPackages = @(Get-Content $safeModePackageList)
 
 	if ($matchedPackages.Count -le 0) {
 		Write-Host "[ERROR] Safe Mode package list not found! Please report this to Atlas." -ForegroundColor Red
@@ -295,12 +298,21 @@ function ProcessCab($cabPath) {
 	Write-Host ("-" * 84) -ForegroundColor Magenta
 
 	Write-Host "[INFO] Checking certificate..."
+	$certificateValidated = $false
 	try {
-		$cert = (Get-AuthenticodeSignature $cabPath).SignerCertificate
-		if ($cert.Extensions.EnhancedKeyUsages.Value -ne "1.3.6.1.4.1.311.10.3.6") {
-			Write-Host "[ERROR] Cert doesn't have proper key usages, can't continue." -ForegroundColor Red
-			$script:errorLevel++
-			return $false
+		$cert = (Get-AuthenticodeSignature -FilePath $cabPath).SignerCertificate
+		if ($null -eq $cert) {
+			throw "No signer certificate was found."
+		}
+
+		$ekuValues = @(
+			$cert.Extensions |
+				Where-Object { $_ -is [System.Security.Cryptography.X509Certificates.X509EnhancedKeyUsageExtension] } |
+				ForEach-Object { $_.EnhancedKeyUsages | ForEach-Object { $_.Value } }
+		)
+
+		if ($ekuValues -notcontains "1.3.6.1.4.1.311.10.3.6") {
+			throw "Cert doesn't have proper key usages, can't continue."
 		}
 
 		# add test cert
@@ -309,18 +321,28 @@ function ProcessCab($cabPath) {
 		if (!(Test-Path "$certRegPath")) {
 			New-Item -Path $certRegPath -Force | Out-Null
 		}
+
+		$certificateValidated = $true
 	} catch {
 		Write-Host "[ERROR] Cert error from '$cabPath': $_" -ForegroundColor Red
 		$script:errorLevel++
+	}
+
+	if (-not $certificateValidated) {
 		return $false
 	}
 
 	Write-Host "[INFO] Adding package..."
+	$packageAdded = $true
 	try {
 		Add-WindowsPackage -Online -PackagePath $cabPath -NoRestart -IgnoreCheck -LogLevel 1 *>$null
 	} catch {
 		Write-Host "[ERROR] Error when adding package '$cabPath': $_" -ForegroundColor Red
 		$script:errorLevel++
+		$packageAdded = $false
+	}
+
+	if (-not $packageAdded) {
 		return $false
 	}
 
@@ -341,7 +363,7 @@ function MakeRepairSource {
 
 	# get list of Atlas manifests
 	Write-Host "[INFO] Getting manifests..."
-	$manifests = Get-ChildItem "$windir\WinSxS\Manifests" -File -Filter "*$version*"
+	$manifests = @(Get-ChildItem "$windir\WinSxS\Manifests" -File -Filter "*$version*")
 	if ($manifests.Count -eq 0) {
 		Write-Host "[WARN] No manifests found! Can't create repair source." -ForegroundColor Yellow
 		return $false

--- a/src/playbook/Executables/BACKUP.ps1
+++ b/src/playbook/Executables/BACKUP.ps1
@@ -3,20 +3,37 @@ param (
 	[string]$FilePath
 )
 
+Set-StrictMode -Version 3.0
+
 if (Test-Path $FilePath) { exit }
 
 $content = [System.Collections.Generic.List[string]]::new()
 $content.Add("Windows Registry Editor Version 5.00")
-Get-ChildItem "HKLM:\SYSTEM\CurrentControlSet\Services" | ForEach-Object {
-	try {
-		$values = Get-ItemProperty -Path $_.PSPath -Name 'Start', 'Description' -EA Stop
-		if ($values.Description -notmatch 'Windows Defender') {
-			$content.Add("`n[$($_.Name)]")
-			$content.Add('"Start"=dword:0000000' + $values.Start)	
-		} else {
-			Write-Output "Excluding $($_.Name)..."
-		}
-	} catch {}
+foreach ($serviceKey in (Get-ChildItem "HKLM:\SYSTEM\CurrentControlSet\Services")) {
+	$serviceProps = Get-ItemProperty -Path $serviceKey.PSPath -ErrorAction SilentlyContinue
+	if ($null -eq $serviceProps) {
+		continue
+	}
+
+	$startProperty = $serviceProps.PSObject.Properties['Start']
+	if ($null -eq $startProperty) {
+		continue
+	}
+	$startValue = $startProperty.Value
+
+	$description = $null
+	$descriptionProperty = $serviceProps.PSObject.Properties['Description']
+	if ($null -ne $descriptionProperty) {
+		$description = [string]$descriptionProperty.Value
+	}
+
+	if (($null -ne $description) -and ($description -match 'Windows Defender')) {
+		Write-Output "Excluding $($serviceKey.Name)..."
+		continue
+	}
+
+	$content.Add("`n[$($serviceKey.Name)]")
+	$content.Add('"Start"=dword:0000000' + $startValue)
 }
 
 # Set-Content can only do UTF8 with BOM, which doesn't work with reg.exe

--- a/src/playbook/Executables/NGEN.ps1
+++ b/src/playbook/Executables/NGEN.ps1
@@ -1,6 +1,8 @@
 # speeds up powershell startup time by 10x
+Set-StrictMode -Version 3.0
+
 $env:path = "$([Runtime.InteropServices.RuntimeEnvironment]::GetRuntimeDirectory());" + $env:path
-[AppDomain]::CurrentDomain.GetAssemblies().Location | ? {$_} | % {
+[AppDomain]::CurrentDomain.GetAssemblies().Location | Where-Object { $_ } | ForEach-Object {
     Write-Host "NGENing: $(Split-Path $_ -Leaf)" -ForegroundColor Yellow
     ngen install $_ | Out-Null
 }

--- a/src/playbook/Executables/SETTABST.ps1
+++ b/src/playbook/Executables/SETTABST.ps1
@@ -4,7 +4,7 @@ param (
 if (!$Browser) {
     $ArgString = "`"${Env:WinDir}\AtlasModules\Scripts\taskbarPins.ps1`""
     $Action = New-ScheduledTaskAction -Execute "powershell.exe" `
-        -Argument "-NoProfile -ExecutionPolicy Bypass -File $ArgString `"$Browser`""
+        -Argument "-NoProfile -ExecutionPolicy RemoteSigned -File $ArgString `"$Browser`""
     $Trigger = New-ScheduledTaskTrigger -AtLogon
     $Principal = New-ScheduledTaskPrincipal -GroupId "Users" -RunLevel Highest
 
@@ -13,12 +13,11 @@ if (!$Browser) {
 else {
     $ArgString = "`"${Env:WinDir}\AtlasModules\Scripts\taskbarPins.ps1`""
     $Action = New-ScheduledTaskAction -Execute "powershell.exe" `
-        -Argument "-NoProfile -ExecutionPolicy Bypass -File $ArgString `"$Browser`""
+        -Argument "-NoProfile -ExecutionPolicy RemoteSigned -File $ArgString `"$Browser`""
     $Trigger = New-ScheduledTaskTrigger -AtLogon
     $Principal = New-ScheduledTaskPrincipal -GroupId "Users" -RunLevel Highest
 
     Register-ScheduledTask -TaskName "TaskBarPins" -Action $Action -Trigger $Trigger -Principal $Principal -Force
 }
-
 
 

--- a/src/playbook/Executables/SOFTWARE.ps1
+++ b/src/playbook/Executables/SOFTWARE.ps1
@@ -14,6 +14,7 @@ param (
 $timeouts = @("--connect-timeout", "10", "--retry", "5", "--retry-delay", "0", "--retry-all-errors")
 $msiArgs = "/qn /quiet /norestart ALLUSERS=1 REBOOT=ReallySuppress"
 $arm = ((Get-CimInstance -Class Win32_ComputerSystem).SystemType -match 'ARM64') -or ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64')
+$toolboxDownloadLatest = "https://github.com/Atlas-OS/atlas-toolbox/releases/latest/download/AtlasToolbox-Setup.exe"
 
 # Create a temporary directory
 function Remove-TempDirectory { Pop-Location; Remove-Item -Path $tempDir -Force -Recurse -EA 0 }
@@ -23,14 +24,16 @@ Push-Location $tempDir
 
 # Toolbox
 if ($Toolbox) {
-    & curl.exe -LSs "https://github.com/Atlas-OS/atlas-toolbox/releases/latest/download/AtlasToolbox-Setup.exe" -o "$tempDir\toolbox.exe" $timeouts
+    Write-Output "Downloading Toolbox..."
+    & curl.exe -LSs $toolboxDownloadLatest -o "$tempDir\toolbox.exe" $timeouts
+
     if (!$?) {
         Write-Error "Downloading Toolbox failed."
         exit 1
     }
 
     Write-Output "Installing Toolbox..."
-    Start-Process -FilePath "$tempDir\toolbox.exe" -WindowStyle Hidden -ArgumentList '/verysilent /install /MERGETASKS="desktopicon"'
+    Start-Process -FilePath "$tempDir\toolbox.exe" -WindowStyle Hidden -ArgumentList '/verysilent /install /MERGETASKS="desktopicon"' -Wait
 
     exit
 }
@@ -46,18 +49,9 @@ if ($Brave) {
     }
 
     Write-Output "Installing Brave..."
-    Start-Process -FilePath "$tempDir\BraveSetup.exe" -WindowStyle Hidden -ArgumentList '/silent /install'
+    Start-Process -FilePath "$tempDir\BraveSetup.exe" -WindowStyle Hidden -ArgumentList '/silent /install' -Wait
 
-    do {
-        $processesFound = Get-Process | Where-Object { "BraveSetup" -contains $_.Name } | Select-Object -ExpandProperty Name
-        if ($processesFound) {
-            Write-Output "Still running BraveSetup."
-            Start-Sleep -Seconds 2
-        }
-        else {
-            Remove-TempDirectory
-        }
-    } until (!$processesFound)
+    Remove-TempDirectory
 
     Stop-Process -Name "brave" -Force -EA 0
 
@@ -139,7 +133,7 @@ foreach ($a in $vcredists.GetEnumerator()) {
         }
         else {
             $msiPaths | ForEach-Object {
-                Start-Process -FilePath "msiexec.exe" -ArgumentList "/log `"$msiDir\logfile.log`" /i `"$_`" $msiArgs" -WindowStyle Hidden
+                Start-Process -FilePath "msiexec.exe" -ArgumentList "/log `"$msiDir\logfile.log`" /i `"$_`" $msiArgs" -WindowStyle Hidden -Wait
             }
         }
     }


### PR DESCRIPTION
### Questions
- [x] Did you test your changes or double-check that they work?
- [x] Did you read and follow the [Atlas Contribution Guidelines](https://docs.atlasos.net/contributions/)?

### Describe your pull request
- harden toolbox/software and package-install execution paths with safer defaults and stricter handling
- improve update-driver and remove-edge wrappers for clearer flow, error handling, and non-interactive behavior
- align supporting scripts with stricter PowerShell usage and consistent execution policy choices
