### PR TITLE
Refactor APPLYDUHIVE HKCU path discovery

### DIFF
--- a/src/playbook/Executables/APPLYDUHIVE.ps1
+++ b/src/playbook/Executables/APPLYDUHIVE.ps1
@@ -1,69 +1,52 @@
-# Load YamlDotNet for YAML parsing
-# YamlDotNet by Antoine Aubry - https://github.com/aaubry/YamlDotNet (MIT License)
-Add-Type -Path "$PSScriptRoot\YamlDotNet.dll"
-
-function ConvertFrom-Yaml {
-    param([string]$YamlString)
-    $reader = New-Object System.IO.StringReader($YamlString)
-    $yamlStream = New-Object YamlDotNet.RepresentationModel.YamlStream
-    $yamlStream.Load($reader)
-    $reader.Close()
-
-    function ConvertNode($node) {
-        if ($node -is [YamlDotNet.RepresentationModel.YamlMappingNode]) {
-            $ht = @{}
-            foreach ($pair in $node.Children) {
-                $ht[$pair.Key.Value] = ConvertNode $pair.Value
-            }
-            return $ht
-        }
-        elseif ($node -is [YamlDotNet.RepresentationModel.YamlSequenceNode]) {
-            $arr = @()
-            foreach ($item in $node.Children) {
-                $arr += ConvertNode $item
-            }
-            return $arr
-        }
-        else {
-            return $node.Value
-        }
-    }
-
-    return ConvertNode $yamlStream.Documents[0].RootNode
-}
-
 $configurationFolder = Join-Path $PSScriptRoot "..\Configuration\tweaks"
-$yamlFiles = Get-ChildItem -Path $configurationFolder -Filter *.yml -Recurse
-$RegistryPaths = @()
+$yamlFiles = Get-ChildItem -Path $configurationFolder -Filter *.yml -Recurse -File
+
+$registryPaths = New-Object System.Collections.Generic.HashSet[string]([System.StringComparer]::OrdinalIgnoreCase)
+$pathPattern = [regex]::new('^(?!\s*#).*?\bpath\s*:\s*[''\"]HKCU\\(?<path>[^''\"]+)[''\"]', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase -bor [System.Text.RegularExpressions.RegexOptions]::Multiline)
+
 foreach ($yamlFile in $yamlFiles) {
-    $yamlContent = Get-Content $yamlFile.FullName -Raw
-    $parsedYaml = ConvertFrom-Yaml $yamlContent
-    foreach ($entry in $parsedYaml) {
-        foreach ($value in $entry.actions.path) {
-            if ($value -like 'HKCU') {
-                if (!$RegistryPaths.Contains($value.Substring(4))) { $RegistryPaths += $value.Substring(4) }
-            }
+    $yamlContent = Get-Content -Path $yamlFile.FullName -Raw
+    foreach ($match in $pathPattern.Matches($yamlContent)) {
+        $relativePath = $match.Groups['path'].Value.Trim()
+        if (![string]::IsNullOrWhiteSpace($relativePath)) {
+            $null = $registryPaths.Add($relativePath)
         }
     }
 }
 
-foreach ($path in $RegistryPaths) {
-    $source = "Registry::HKCU\$path"
-    $destination = "Registry::HKU\AME_UserHive_Default\$path"
-    $values = Get-ItemProperty -Path $source -ErrorAction SilentlyContinue
-    if ($values) {
-        foreach ($property in $values.PSObject.Properties) {
-            if ($property.Name -ne "PSPath" -and $property.Name -ne "PSParentPath" -and $property.Name -ne "PSChildName" -and $property.Name -ne "PSDrive" -and $property.Name -ne "PSProvider") {
-                if (-not (Test-Path $destination)) {
-                    New-Item -Path $destination -Force | Out-Null
-                }
-                if (-not ((Get-ItemProperty $destination -ErrorAction SilentlyContinue).PSObject.Properties.Name -contains $property.Name)) {
-                    New-ItemProperty -Path $destination -Name $property.Name -Value $property.Value | Out-Null
-                }
-                else {
-                    Set-ItemProperty -Path $destination -Name $property.Name -Value $property.Value
-                }
-            }
+if ($registryPaths.Count -eq 0) {
+    Write-Warning "No HKCU registry paths were found in tweak YAML files."
+    exit
+}
+
+foreach ($relativePath in ($registryPaths | Sort-Object)) {
+    $sourceKey = $null
+    $destinationKey = $null
+
+    try {
+        $sourceKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey($relativePath, $false)
+        if ($null -eq $sourceKey) {
+            continue
+        }
+
+        $destinationKey = [Microsoft.Win32.Registry]::Users.CreateSubKey("AME_UserHive_Default\$relativePath")
+        if ($null -eq $destinationKey) {
+            Write-Warning "Failed to create destination key: HKU\\AME_UserHive_Default\\$relativePath"
+            continue
+        }
+
+        foreach ($valueName in $sourceKey.GetValueNames()) {
+            $value = $sourceKey.GetValue($valueName, $null, [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames)
+            $kind = $sourceKey.GetValueKind($valueName)
+            $destinationKey.SetValue($valueName, $value, $kind)
+        }
+    }
+    finally {
+        if ($null -ne $destinationKey) {
+            $destinationKey.Close()
+        }
+        if ($null -ne $sourceKey) {
+            $sourceKey.Close()
         }
     }
 }


### PR DESCRIPTION
### Questions
- [x] Did you test your changes or double-check that they work?
- [x] Did you read and follow the [Atlas Contribution Guidelines](https://docs.atlasos.net/contributions/)?

### Describe your pull request
- simplify APPLYDUHIVE by extracting HKCU registry paths from tweak YAML content directly
- keep path collection deterministic and case-insensitive before syncing values to the default user hive
- reduce coupling to YAML object parsing logic while preserving existing copy behavior
