### PR TITLE
Update CI workflow refs and context-menu tweak definitions

### DIFF
--- a/.github/workflows/apbx.yaml
+++ b/.github/workflows/apbx.yaml
@@ -16,6 +16,7 @@ on:
 
 env:
   SXSC_REPO: "https://github.com/Atlas-OS/sxsc"
+  SXSC_REF: "a351a94f0feeab200032a41d7577bd150b0c05e2"
 
 jobs:
   build:
@@ -23,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || github.ref }}
           token: ${{ secrets.RUNNER_SECRET }}
@@ -33,7 +34,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v46.0.1
+        uses: tj-actions/changed-files@v47.0.4
         with:
           files_yaml: |
             sxsc:
@@ -67,6 +68,8 @@ jobs:
       - name: Clone the sxsc repository
         run: |
           git clone --depth=1 ${{ env.SXSC_REPO }}
+          git -C sxsc fetch --depth=1 origin ${{ env.SXSC_REF }}
+          git -C sxsc checkout --detach ${{ env.SXSC_REF }}
           Copy-Item -Path "configs" -Destination ".\sxsc\configs" -Recurse -Force
         working-directory: ..
         if: env.runSxsc == 'true'
@@ -133,7 +136,7 @@ jobs:
         working-directory: src\playbook
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         if: ${{ steps.create-pb.outcome != 'skipped' }}
         with:
           name: Atlas Playbook

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -10,4 +10,4 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v4
+    - uses: actions/labeler@v6.0.1

--- a/src/playbook/Configuration/tweaks/qol/explorer/add-context-menus/merge-as-trustedinstaller.yml
+++ b/src/playbook/Configuration/tweaks/qol/explorer/add-context-menus/merge-as-trustedinstaller.yml
@@ -3,17 +3,17 @@ title: Add 'Merge as TrustedInstaller' to Context Menu
 description: Adds 'Merge as TrustedInstaller' to context menu for registry files
 actions:
   - !registryValue:
-    path: 'HKCR\regfile\Shell\RunAs'
+    path: 'HKLM\Software\Classes\regfile\Shell\RunAs'
     value: ''
     data: 'Merge As TrustedInstaller'
     type: REG_SZ
   - !registryValue:
-    path: 'HKCR\regfile\Shell\RunAs'
+    path: 'HKLM\Software\Classes\regfile\Shell\RunAs'
     value: 'HasLUAShield'
     data: '1'
     type: REG_SZ
   - !registryValue:
-    path: 'HKCR\regfile\Shell\RunAs\Command'
+    path: 'HKLM\Software\Classes\regfile\Shell\RunAs\Command'
     value: ''
     data: 'cmd /c "%windir%\AtlasModules\Scripts\RunAsTI.cmd" "%1"'
     type: REG_SZ

--- a/src/playbook/Configuration/tweaks/qol/shell/restore-old-context-menu.yml
+++ b/src/playbook/Configuration/tweaks/qol/shell/restore-old-context-menu.yml
@@ -3,14 +3,7 @@ title: Restore Old Context Menu
 description: Restores the old context menu in Windows 11
 builds: [ '>=22000' ]
 actions:
-  - !registryValue:
-    path: 'HKCU\Software\Classes\CLSID\{86ca1aa0-34aa-4e8b-a509-50c905bae2a2}\InprocServer32'
-    value: ''
-    data: ''
-    type: REG_SZ
-    
-    # Fall back for OOBE cause it seems not to work 
-  - !powerShell:
+  - !cmd:
     command: 'reg add "HKCU\Software\Classes\CLSID\{86ca1aa0-34aa-4e8b-a509-50c905bae2a2}\InprocServer32" /t REG_SZ /d "" /f > nul'
-    exeDir: true
-    oobe: only
+    runas: currentUserElevated
+    wait: true


### PR DESCRIPTION
### Questions
- [x] Did you test your changes or double-check that they work?
- [x] Did you read and follow the [Atlas Contribution Guidelines](https://docs.atlasos.net/contributions/)?

### Describe your pull request
- bump/pin workflow action versions and lock the sxsc checkout to a specific ref in CI
- move trusted-installer merge context-menu entries from HKCR to explicit HKLM\Software\Classes paths
- adjust old-context-menu restore tweak execution path to improve reliability under playbook execution
