### PR TITLE
chore: Update bug report template to 25H2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -57,7 +57,7 @@ body:
     label: Atlas Version
     description: 'If you''re on v0.4.0, see the workarounds page first: https://github.com/orgs/Atlas-OS/projects/7/views/5'
     options:
-    - Atlas v0.5.0 for Windows 10 22H2
+    - Atlas v0.5.0 for Windows 11 24H2
     - Atlas v0.5.0 for Windows 11 25H2
   validations:
     required: true


### PR DESCRIPTION
### Questions
- [x] Did you test your changes or double-check that they work?
- [x] Did you read and follow the [Atlas Contribution Guidelines](https://docs.atlasos.net/contributions/)?

### Describe your pull request
Bumps the template to 25H2, which is the current Windows release that is supported by AtlasOS.

