### PR TITLE
refactor: replace deprecated reg/sc/wmic/setx/schtasks with PowerShell cmdlets

### DIFF
--- a/.github/linters/PSScriptAnalyzerSettings.psd1
+++ b/.github/linters/PSScriptAnalyzerSettings.psd1
@@ -5,6 +5,16 @@
         # Atlas scripts use Write-Host intentionally for colored playbook output
         'PSAvoidUsingWriteHost',
         # Positional parameters are common in short Atlas helper calls
-        'PSAvoidUsingPositionalParameters'
+        'PSAvoidUsingPositionalParameters',
+        # Internal Atlas scripts are not published cmdlets; ShouldProcess is not applicable
+        'PSUseShouldProcessForStateChangingFunctions',
+        # Internal function names do not need to follow module-publishing conventions
+        'PSUseSingularNouns',
+        # InstallSoftware.ps1 uses global vars intentionally for its progress display state machine
+        'PSAvoidGlobalVars',
+        # BOM handling is a per-file encoding decision, not enforced project-wide
+        'PSUseBOMForUnicodeEncodedFile',
+        # Script-level params used inside nested functions trigger a false positive in PSSA
+        'PSReviewUnusedParameter'
     )
 }

--- a/.github/linters/PSScriptAnalyzerSettings.psd1
+++ b/.github/linters/PSScriptAnalyzerSettings.psd1
@@ -1,0 +1,10 @@
+@{
+    Severity = @('Error', 'Warning')
+
+    ExcludeRules = @(
+        # Atlas scripts use Write-Host intentionally for colored playbook output
+        'PSAvoidUsingWriteHost',
+        # Positional parameters are common in short Atlas helper calls
+        'PSAvoidUsingPositionalParameters'
+    )
+}

--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -1,0 +1,47 @@
+name: Lint PowerShell
+
+on:
+  push:
+    paths:
+      - "src/**/*.ps1"
+      - "src/**/*.psm1"
+      - ".github/linters/PSScriptAnalyzerSettings.psd1"
+      - ".github/workflows/lint-powershell.yml"
+  pull_request:
+    paths:
+      - "src/**/*.ps1"
+      - "src/**/*.psm1"
+      - ".github/linters/PSScriptAnalyzerSettings.psd1"
+      - ".github/workflows/lint-powershell.yml"
+  workflow_dispatch:
+
+jobs:
+  psscriptanalyzer:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout code
+        # gh api repos/actions/checkout/commits/v4 --jq '.sha'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          # Pin to a specific version so results are reproducible
+          # Update RequiredVersion when a new release ships on PowerShell Gallery
+          Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.25.0 -Force -Scope CurrentUser
+
+      - name: Run PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          $settings = '.github/linters/PSScriptAnalyzerSettings.psd1'
+          $results = Get-ChildItem -Path 'src' -Recurse -Include '*.ps1','*.psm1' |
+              Invoke-ScriptAnalyzer -Settings $settings
+
+          if ($results) {
+              $results | Format-Table -AutoSize
+              Write-Host "::error::PSScriptAnalyzer found $($results.Count) issue(s)."
+              exit 1
+          }
+
+          Write-Host "No issues found."

--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -21,8 +21,8 @@ jobs:
 
     steps:
       - name: Checkout code
-        # gh api repos/actions/checkout/commits/v4 --jq '.sha'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        # gh api repos/actions/checkout/commits/v6.0.2 --jq '.sha'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install PSScriptAnalyzer
         shell: pwsh

--- a/src/dependencies/local-build.ps1
+++ b/src/dependencies/local-build.ps1
@@ -32,8 +32,6 @@ if ($Removals) {
 $runtimeInformation = [System.Runtime.InteropServices.RuntimeInformation]
 $osPlatform = [System.Runtime.InteropServices.OSPlatform]
 $IsWindowsPlatform = $runtimeInformation::IsOSPlatform($osPlatform::Windows)
-$IsLinuxPlatform = $runtimeInformation::IsOSPlatform($osPlatform::Linux)
-$IsMacOSPlatform = $runtimeInformation::IsOSPlatform($osPlatform::OSX)
 # lazy temp staging so we only touch disk when needed
 $rootTempDir = $null
 $playbookTempPath = $null

--- a/src/playbook/Executables/ASSOC.ps1
+++ b/src/playbook/Executables/ASSOC.ps1
@@ -156,7 +156,7 @@ function Get-Time {
   Write-Output $dateTimeHex
 }
 
-function Delete-UserChoiceKey {
+function Remove-UserChoiceKey {
   param (
     [Parameter( Position = 0, Mandatory = $True )]
     [String]
@@ -229,7 +229,7 @@ for ($i = 2; $i -lt $args.Length; $i++) {
     New-Item -Path "HKU:\$Hive\SOFTWARE\Microsoft\Windows\Shell\Associations\UrlAssociations\$($splitArg[1])" -Force | Out-Null
     }
     If (Test-Path "HKU:\$Hive\SOFTWARE\Microsoft\Windows\Shell\Associations\UrlAssociations\$($splitArg[1])\UserChoice") {
-    Delete-UserChoiceKey "$Hive\SOFTWARE\Microsoft\Windows\Shell\Associations\UrlAssociations\$($splitArg[1])\UserChoice"
+    Remove-UserChoiceKey "$Hive\SOFTWARE\Microsoft\Windows\Shell\Associations\UrlAssociations\$($splitArg[1])\UserChoice"
     }
     If (-NOT (Test-Path "HKU:\$Hive\SOFTWARE\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts")) {
     New-Item -Path "HKU:\$Hive\SOFTWARE\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" -Force | Out-Null
@@ -246,7 +246,7 @@ for ($i = 2; $i -lt $args.Length; $i++) {
     New-Item -Path "HKU:\$Hive\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\FileExts\$($splitArg[0])" -Force | Out-Null
     }
     If (Test-Path "HKU:\$Hive\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\FileExts\$($splitArg[0])\UserChoice") {
-    Delete-UserChoiceKey "$Hive\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\FileExts\$($splitArg[0])\UserChoice"
+    Remove-UserChoiceKey "$Hive\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\FileExts\$($splitArg[0])\UserChoice"
     }
     If (-NOT (Test-Path "HKU:\$Hive\SOFTWARE\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts")) {
     New-Item -Path "HKU:\$Hive\SOFTWARE\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" -Force | Out-Null

--- a/src/playbook/Executables/AtlasModules/Scripts/ASSOC.ps1
+++ b/src/playbook/Executables/AtlasModules/Scripts/ASSOC.ps1
@@ -156,7 +156,7 @@ function Get-Time {
   Write-Output $dateTimeHex
 }
 
-function Delete-UserChoiceKey {
+function Remove-UserChoiceKey {
   param (
     [Parameter( Position = 0, Mandatory = $True )]
     [String]
@@ -229,7 +229,7 @@ for ($i = 2; $i -lt $args.Length; $i++) {
     New-Item -Path "HKU:\$Hive\SOFTWARE\Microsoft\Windows\Shell\Associations\UrlAssociations\$($splitArg[1])" -Force | Out-Null
     }
     If (Test-Path "HKU:\$Hive\SOFTWARE\Microsoft\Windows\Shell\Associations\UrlAssociations\$($splitArg[1])\UserChoice") {
-    Delete-UserChoiceKey "$Hive\SOFTWARE\Microsoft\Windows\Shell\Associations\UrlAssociations\$($splitArg[1])\UserChoice"
+    Remove-UserChoiceKey "$Hive\SOFTWARE\Microsoft\Windows\Shell\Associations\UrlAssociations\$($splitArg[1])\UserChoice"
     }
     If (-NOT (Test-Path "HKU:\$Hive\SOFTWARE\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts")) {
     New-Item -Path "HKU:\$Hive\SOFTWARE\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" -Force | Out-Null
@@ -246,7 +246,7 @@ for ($i = 2; $i -lt $args.Length; $i++) {
     New-Item -Path "HKU:\$Hive\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\FileExts\$($splitArg[0])" -Force | Out-Null
     }
     If (Test-Path "HKU:\$Hive\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\FileExts\$($splitArg[0])\UserChoice") {
-    Delete-UserChoiceKey "$Hive\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\FileExts\$($splitArg[0])\UserChoice"
+    Remove-UserChoiceKey "$Hive\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\FileExts\$($splitArg[0])\UserChoice"
     }
     If (-NOT (Test-Path "HKU:\$Hive\SOFTWARE\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts")) {
     New-Item -Path "HKU:\$Hive\SOFTWARE\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" -Force | Out-Null

--- a/src/playbook/Executables/AtlasModules/Scripts/Modules/Debloat/Debloat.psm1
+++ b/src/playbook/Executables/AtlasModules/Scripts/Modules/Debloat/Debloat.psm1
@@ -1,66 +1,74 @@
-function Set-ContentDelivery{
+function Set-ContentDelivery {
     Write-Host "Setting Content Delivery"
-    $key = "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\ContentDeliveryManager";
-    $data = "0"
+    # ContentDeliveryManager controls Windows suggestions, sponsored apps, and lock screen ads.
+    # Setting all these values to 0 stops Windows from silently installing apps and showing promotions.
+    $key = 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\ContentDeliveryManager'
+    $data = 0
     $values = @(
-    "ContentDeliveryAllowed",
-    "FeatureManagementEnabled",
-    "SubscribedContentEnabled",
-    "RemediationRequired",
-    "OemPreInstalledAppsEnabled",
-    "PreInstalledAppsEnabled",
-    "PreInstalledAppsEverEnabled",
-    "SilentInstalledAppsEnabled",
-    "EnableAccountNotifications",
-    "SubscribedContent-310093Enabled",
-    "SubscribedContent-338393Enabled",
-    "SubscribedContent-353694Enabled",
-    "SubscribedContent-353696Enabled",
-    "SubscribedContent-338388Enabled",
-    "SubscribedContent-338387Enabled",
-    "SubscribedContent-338389Enabled",
-    "SystemPaneSuggestionsEnabled",
-    "RotatingLockScreenOverlayEnabled",
-    "SoftLandingEnabled"
+        'ContentDeliveryAllowed',
+        'FeatureManagementEnabled',
+        'SubscribedContentEnabled',
+        'RemediationRequired',
+        'OemPreInstalledAppsEnabled',
+        'PreInstalledAppsEnabled',
+        'PreInstalledAppsEverEnabled',
+        'SilentInstalledAppsEnabled',
+        'EnableAccountNotifications',
+        'SubscribedContent-310093Enabled',
+        'SubscribedContent-338393Enabled',
+        'SubscribedContent-353694Enabled',
+        'SubscribedContent-353696Enabled',
+        'SubscribedContent-338388Enabled',
+        'SubscribedContent-338387Enabled',
+        'SubscribedContent-338389Enabled',
+        'SystemPaneSuggestionsEnabled',
+        'RotatingLockScreenOverlayEnabled',
+        'SoftLandingEnabled'
     )
 
-    foreach ($value in $values){
-        reg add $key /v $value /t REG_DWORD /d $data /f > $null
+    $null = New-Item -Path $key -Force -ErrorAction SilentlyContinue
+    foreach ($value in $values) {
+        Set-ItemProperty -Path $key -Name $value -Value $data -Type DWord -Force
     }
-    reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\SystemSettings\AccountNotifications" /t REG_DWORD /v 'EnableAccountNotifications' /d "0" /f > $null
+
+    # This separate key controls account-related notifications in the Settings app
+    $path = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\SystemSettings\AccountNotifications'
+    $null = New-Item -Path $path -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path $path -Name 'EnableAccountNotifications' -Value 0 -Type DWord -Force
 }
 
-function Set-StorageSense{
+function Set-StorageSense {
     Write-Host "Setting Storage Sense"
-    $key = "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\StorageSense\Parameters\StoragePolicy"
-    $values = @(
-        "32",
-        "02",
-        "128",
-        "08",
-        "256"
-    )
+    # StorageSense uses numeric value names as identifiers for each cleanup policy option.
+    # Values set to 0 are disabled; values set to 1 or higher control cleanup intervals.
+    $key = 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\StorageSense\Parameters\StoragePolicy'
+    $null = New-Item -Path $key -Force -ErrorAction SilentlyContinue
 
-    foreach ($value in $values){
-        reg add $key /t REG_DWORD /v $value /d "0" /f
+    # Disable cleanup for: downloads (32), recycle bin (02), temp files (128), offline files (08), previous versions (256)
+    foreach ($value in @('32', '02', '128', '08', '256')) {
+        Set-ItemProperty -Path $key -Name $value -Value 0 -Type DWord -Force
     }
-    reg add $key /t REG_DWORD /v '01' /d "1" /f
-    reg add $key /t REG_DWORD /v '1024' /d "1" /f
-    reg add $key /t REG_DWORD /v '04' /d "1" /f
-    reg add $key /t REG_DWORD /v '2048' /d "30" /f
-    Start-ScheduledTask -TaskPath "\Microsoft\Windows\DiskCleanup" -TaskName "SilentCleanup"
+    Set-ItemProperty -Path $key -Name '01'   -Value 1  -Type DWord -Force  # Enable Storage Sense itself
+    Set-ItemProperty -Path $key -Name '1024' -Value 1  -Type DWord -Force  # Run when low on disk space
+    Set-ItemProperty -Path $key -Name '04'   -Value 1  -Type DWord -Force  # Delete temp files
+    Set-ItemProperty -Path $key -Name '2048' -Value 30 -Type DWord -Force  # Keep files in recycle bin for 30 days
+    # Run the cleanup task immediately so settings take effect without waiting for the next scheduled run
+    Start-ScheduledTask -TaskPath '\Microsoft\Windows\DiskCleanup' -TaskName 'SilentCleanup'
 }
 
 function Set-DisableStorageSense {
     Write-Host "Disabling Storage Sense"
+    # Reserved storage is disk space Windows sets aside for updates; freeing it saves space on small drives
     dism.exe /Online /Set-ReservedStorageState /State:Disabled
 }
 
 function Set-DisabledScheduledTasks {
     Write-Host "Disabling ScheduledTasks"
-    Disable-ScheduledTask -TaskPath "\Microsoft\Windows\Application Experience\" -TaskName "PcaPatchDbTask"
-    Disable-ScheduledTask -TaskPath "\Microsoft\Windows\AppxDeploymentClient\" -TaskName "UCPD velocity" -ErrorAction SilentlyContinue
-    Disable-ScheduledTask -TaskPath "\Microsoft\Windows\Flighting\FeatureConfig\" -TaskName "UsageDataReporting" -ErrorAction SilentlyContinue
+    # PcaPatchDbTask runs program compatibility scans after app installs; not needed on a clean system
+    Disable-ScheduledTask -TaskPath '\Microsoft\Windows\Application Experience\' -TaskName 'PcaPatchDbTask'
+    # UCPD velocity and UsageDataReporting send usage telemetry to Microsoft
+    Disable-ScheduledTask -TaskPath '\Microsoft\Windows\AppxDeploymentClient\' -TaskName 'UCPD velocity' -ErrorAction SilentlyContinue
+    Disable-ScheduledTask -TaskPath '\Microsoft\Windows\Flighting\FeatureConfig\' -TaskName 'UsageDataReporting' -ErrorAction SilentlyContinue
 }
 
 Export-ModuleMember -Function @()

--- a/src/playbook/Executables/AtlasModules/Scripts/Modules/Performance/Performance.psm1
+++ b/src/playbook/Executables/AtlasModules/Scripts/Modules/Performance/Performance.psm1
@@ -1,6 +1,8 @@
 # Optimizes NTFS for performance
 function Optimize-NTFS {
+    # Stop tracking last-access timestamps on files; reduces unnecessary disk writes
     fsutil behavior set disablelastaccess 1
+    # Disable 8.3 short filename generation; speeds up directory operations on large folders
     fsutil behavior set disable8dot3 1
 }
 
@@ -11,46 +13,46 @@ function Disable-AutoFolderDiscovery {
 
 # Disables background apps to reduce resource usage
 function Disable-BackgroundApps {
-    $key1 = "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\BackgroundAccessApplications"
-    reg add $key1 /v "GlobalUserDisabled" /t REG_DWORD /d 1 /f
+    # Prevents all UWP apps from running in the background globally for this user
+    $key1 = 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\BackgroundAccessApplications'
+    $null = New-Item -Path $key1 -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path $key1 -Name 'GlobalUserDisabled' -Value 1 -Type DWord -Force
 
-    $key2 = "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Search"
-    reg add $key2 /v "BackgroundAppGlobalToggle" /t REG_DWORD /d 0 /f
+    # Stops the Windows Search indexer from running background tasks
+    $key2 = 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Search'
+    $null = New-Item -Path $key2 -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path $key2 -Name 'BackgroundAppGlobalToggle' -Value 0 -Type DWord -Force
 }
 
 # Disables Xbox Game Bar and related settings
 function Disable-GameBar {
-    $keys = @(
-        "HKCU\System\GameConfigStore",
-        "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\GameDVR",
-        "HKCU\SOFTWARE\Microsoft\GameBar",
-        "HKLM\SOFTWARE\Microsoft\WindowsRuntime\ActivatableClassId\Windows.Gaming.GameBar.PresenceServer.Internal.PresenceWriter",
-        "HKLM\SOFTWARE\Policies\Microsoft\Windows\GameDVR",
-        "HKLM\SOFTWARE\Microsoft\PolicyManager\default\ApplicationManagement\AllowGameDVR"
-    )
-    
-    $values = @(
-        @{ Key = $keys[0]; Name = "GameDVR_Enabled"; Data = 0 },
-        @{ Key = $keys[1]; Name = "AppCaptureEnabled"; Data = 0 },
-        @{ Key = $keys[2]; Name = "GamePanelStartupTipIndex"; Data = 3 },
-        @{ Key = $keys[2]; Name = "ShowStartupPanel"; Data = 0 },
-        @{ Key = $keys[2]; Name = "UseNexusForGameBarEnabled"; Data = 0 },
-        @{ Key = $keys[3]; Name = "ActivationType"; Data = 0 },
-        @{ Key = $keys[4]; Name = "AllowGameDVR"; Data = 0 },
-        @{ Key = $keys[5]; Name = "value"; Data = 0 }
+    # New-Item -Force is required before Set-ItemProperty; it silently succeeds if the key already exists
+    $entries = @(
+        @{ Path = 'HKCU:\System\GameConfigStore'; Name = 'GameDVR_Enabled'; Value = 0 },
+        @{ Path = 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\GameDVR'; Name = 'AppCaptureEnabled'; Value = 0 },
+        @{ Path = 'HKCU:\SOFTWARE\Microsoft\GameBar'; Name = 'GamePanelStartupTipIndex'; Value = 3 },
+        @{ Path = 'HKCU:\SOFTWARE\Microsoft\GameBar'; Name = 'ShowStartupPanel'; Value = 0 },
+        @{ Path = 'HKCU:\SOFTWARE\Microsoft\GameBar'; Name = 'UseNexusForGameBarEnabled'; Value = 0 },
+        @{ Path = 'HKLM:\SOFTWARE\Microsoft\WindowsRuntime\ActivatableClassId\Windows.Gaming.GameBar.PresenceServer.Internal.PresenceWriter'; Name = 'ActivationType'; Value = 0 },
+        @{ Path = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\GameDVR'; Name = 'AllowGameDVR'; Value = 0 },
+        @{ Path = 'HKLM:\SOFTWARE\Microsoft\PolicyManager\default\ApplicationManagement\AllowGameDVR'; Name = 'value'; Value = 0 }
     )
 
-    foreach ($entry in $values) {
-        reg add $entry.Key /v $entry.Name /t REG_DWORD /d $entry.Data /f
+    foreach ($entry in $entries) {
+        $null = New-Item -Path $entry.Path -Force -ErrorAction SilentlyContinue
+        Set-ItemProperty -Path $entry.Path -Name $entry.Name -Value $entry.Value -Type DWord -Force
     }
 }
 
 # Disables Modern Standby's SleepStudy feature
 function Disable-SleepStudy {
-    Start-Process -FilePath "wevtutil.exe" -ArgumentList 'set-log "Microsoft-Windows-SleepStudy/Diagnostic" /e:false' -NoNewWindow -Wait
-    Start-Process -FilePath "wevtutil.exe" -ArgumentList 'set-log "Microsoft-Windows-Kernel-Processor-Power/Diagnostic" /e:false' -NoNewWindow -Wait
-    Start-Process -FilePath "wevtutil.exe" -ArgumentList 'set-log "Microsoft-Windows-UserModePowerService/Diagnostic" /e:false' -NoNewWindow -Wait
-    schtasks /Change /TN "\Microsoft\Windows\Power Efficiency Diagnostics\AnalyzeSystem" /Disable
+    # wevtutil must be called via Start-Process because it does not have a PowerShell equivalent
+    # These three event logs are used by SleepStudy to track power activity; disabling them stops the logging
+    Start-Process -FilePath 'wevtutil.exe' -ArgumentList 'set-log "Microsoft-Windows-SleepStudy/Diagnostic" /e:false' -NoNewWindow -Wait
+    Start-Process -FilePath 'wevtutil.exe' -ArgumentList 'set-log "Microsoft-Windows-Kernel-Processor-Power/Diagnostic" /e:false' -NoNewWindow -Wait
+    Start-Process -FilePath 'wevtutil.exe' -ArgumentList 'set-log "Microsoft-Windows-UserModePowerService/Diagnostic" /e:false' -NoNewWindow -Wait
+    # AnalyzeSystem runs on every boot to generate power reports; not useful on a tuned system
+    Disable-ScheduledTask -TaskPath '\Microsoft\Windows\Power Efficiency Diagnostics\' -TaskName 'AnalyzeSystem' -ErrorAction SilentlyContinue
 }
 
 Export-ModuleMember -Function @()

--- a/src/playbook/Executables/AtlasModules/Scripts/Modules/Privacy/Privacy.psm1
+++ b/src/playbook/Executables/AtlasModules/Scripts/Modules/Privacy/Privacy.psm1
@@ -1,114 +1,147 @@
 # Disables Advertising ID for privacy
 function Disable-AdvertisingID {
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\AdvertisingInfo" /v "Enabled" /t REG_DWORD /d 0 /f
-    reg add "HKLM\Software\Policies\Microsoft\Windows\AdvertisingInfo" /v "DisabledByGroupPolicy" /t REG_DWORD /d 1 /f
+    # User-side: stops apps from reading the advertising ID
+    $null = New-Item -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\AdvertisingInfo' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\AdvertisingInfo' -Name 'Enabled' -Value 0 -Type DWord -Force
+    # Machine-side policy: enforces the setting system-wide regardless of user preference
+    $null = New-Item -Path 'HKLM:\Software\Policies\Microsoft\Windows\AdvertisingInfo' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKLM:\Software\Policies\Microsoft\Windows\AdvertisingInfo' -Name 'DisabledByGroupPolicy' -Value 1 -Type DWord -Force
 }
 
 # Disables Sync Provider Notifications in File Explorer
 function Disable-SyncProviderNotifications {
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "ShowSyncProviderNotifications" /t REG_DWORD /d 0 /f
+    # Stops OneDrive and other sync apps from showing ads inside File Explorer
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'ShowSyncProviderNotifications' -Value 0 -Type DWord -Force
 }
 
 # Disables NVIDIA Control Panel telemetry
 function Disable-NvidiaTelemetry {
-    reg add "HKCU\Software\NVIDIA Corporation\NVControlPanel2\Client" /v "OptInOrOutPreference" /t REG_DWORD /d 0 /f
+    # OptInOrOutPreference 0 means opted out of NVIDIA telemetry collection
+    $null = New-Item -Path 'HKCU:\Software\NVIDIA Corporation\NVControlPanel2\Client' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\Software\NVIDIA Corporation\NVControlPanel2\Client' -Name 'OptInOrOutPreference' -Value 0 -Type DWord -Force
 }
 
 # Disables Microsoft Office telemetry
 function Disable-OfficeTelemetry {
-    reg add "HKCU\Software\Policies\Microsoft\office\16.0\common" /v "sendcustomerdata" /t REG_DWORD /d 0 /f
-    reg add "HKCU\Software\Policies\Microsoft\office\common\clienttelemetry" /v "sendtelemetry" /t REG_DWORD /d 3 /f
-    reg add "HKCU\Software\Policies\Microsoft\office\16.0\common" /v "qmenable" /t REG_DWORD /d 0 /f
+    $path1 = 'HKCU:\Software\Policies\Microsoft\office\16.0\common'
+    $null = New-Item -Path $path1 -Force -ErrorAction SilentlyContinue
+    # sendcustomerdata 0 stops Office from sending usage data; qmenable 0 disables Quality Metrics reporting
+    Set-ItemProperty -Path $path1 -Name 'sendcustomerdata' -Value 0 -Type DWord -Force
+    Set-ItemProperty -Path $path1 -Name 'qmenable' -Value 0 -Type DWord -Force
+
+    $path2 = 'HKCU:\Software\Policies\Microsoft\office\common\clienttelemetry'
+    $null = New-Item -Path $path2 -Force -ErrorAction SilentlyContinue
+    # sendtelemetry 3 means disabled; this is an Office-specific enum value, not a simple boolean
+    Set-ItemProperty -Path $path2 -Name 'sendtelemetry' -Value 3 -Type DWord -Force
 }
 
 # Disables Suggested Ways to Finish Setting Up Your Device
 function Disable-DeviceSetupSuggestions {
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\UserProfileEngagement" /v "ScoobeSystemSettingEnabled" /t REG_DWORD /d 0 /f
+    # ScoobeSystemSettingEnabled controls the post-OOBE setup suggestions prompt
+    $null = New-Item -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\UserProfileEngagement' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\UserProfileEngagement' -Name 'ScoobeSystemSettingEnabled' -Value 0 -Type DWord -Force
 }
 
 # Disables .NET CLI Telemetry
 function Disable-NETCLITelemetry {
-    setx DOTNET_CLI_TELEMETRY_OPTOUT 1
+    # 'User' scope writes to HKCU and persists across sessions without needing a restart
+    [Environment]::SetEnvironmentVariable('DOTNET_CLI_TELEMETRY_OPTOUT', '1', 'User')
 }
 
 # Disables Input Telemetry (text, handwriting, and ink)
 function Disable-InputTelemetry {
-    reg add "HKCU\SOFTWARE\Microsoft\InputPersonalization" /v "RestrictImplicitInkCollection" /t REG_DWORD /d 1 /f
-    reg add "HKCU\SOFTWARE\Microsoft\InputPersonalization" /v "RestrictImplicitTextCollection" /t REG_DWORD /d 1 /f
+    # Stops Windows from collecting what you type and draw to improve its handwriting/text models
+    $path = 'HKCU:\SOFTWARE\Microsoft\InputPersonalization'
+    $null = New-Item -Path $path -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path $path -Name 'RestrictImplicitInkCollection' -Value 1 -Type DWord -Force
+    Set-ItemProperty -Path $path -Name 'RestrictImplicitTextCollection' -Value 1 -Type DWord -Force
 }
 
 # Configures Windows Media Player for privacy
 function Set-WindowsMediaPlayer {
-    reg add "HKCU\SOFTWARE\Microsoft\MediaPlayer\Preferences" /v "AcceptedPrivacyStatement" /t REG_DWORD /d 1 /f
+    # AcceptedPrivacyStatement 1 suppresses the privacy prompt on first launch without sending data
+    $null = New-Item -Path 'HKCU:\SOFTWARE\Microsoft\MediaPlayer\Preferences' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\MediaPlayer\Preferences' -Name 'AcceptedPrivacyStatement' -Value 1 -Type DWord -Force
 }
 
 # Disables App Launch Tracking
 function Disable-AppLaunchTracking {
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "Start_TrackProgs" /t REG_DWORD /d 0 /f
+    # Windows normally tracks which apps you open to sort the Start Menu; this disables that
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'Start_TrackProgs' -Value 0 -Type DWord -Force
 }
 
 # Disables Online Speech Recognition
 function Disable-OnlineSpeechRecognition {
-    reg add "HKCU\SOFTWARE\Microsoft\Speech_OneCore\Settings\OnlineSpeechPrivacy" /v "HasAccepted" /t REG_DWORD /d 0 /f
+    # HasAccepted 0 means the user has not agreed to send voice data to Microsoft servers
+    $null = New-Item -Path 'HKCU:\SOFTWARE\Microsoft\Speech_OneCore\Settings\OnlineSpeechPrivacy' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Speech_OneCore\Settings\OnlineSpeechPrivacy' -Name 'HasAccepted' -Value 0 -Type DWord -Force
 }
 
 # Disables Recall Snapshots (24H2+)
 function Disable-RecallSnapshots {
-    Start-Process -FilePath "reg" -ArgumentList "import `"AtlasDesktop\3. General Configuration\AI Features\Recall\Disable Recall Support (default).reg`"" -NoNewWindow -Wait
+    # reg.exe import is the only reliable way to apply a .reg file from PowerShell
+    & reg.exe import "AtlasDesktop\3. General Configuration\AI Features\Recall\Disable Recall Support (default).reg"
 }
 
 # Prevents using Diagnostic Data for Tailored Experiences
 function Disable-TailoredExperiences {
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Privacy" /v "TailoredExperiencesWithDiagnosticDataEnabled" /t REG_DWORD /d 0 /f
-    reg add "HKCU\SOFTWARE\Policies\Microsoft\Windows\CloudContent" /v "DisableTailoredExperiencesWithDiagnosticData" /t REG_DWORD /d 1 /f
+    # User setting: stops Windows from using diagnostic data to personalize tips and suggestions
+    $null = New-Item -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Privacy' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Privacy' -Name 'TailoredExperiencesWithDiagnosticDataEnabled' -Value 0 -Type DWord -Force
+
+    # Policy setting: enforces the same restriction via Group Policy so it cannot be toggled back in Settings
+    $null = New-Item -Path 'HKCU:\SOFTWARE\Policies\Microsoft\Windows\CloudContent' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Policies\Microsoft\Windows\CloudContent' -Name 'DisableTailoredExperiencesWithDiagnosticData' -Value 1 -Type DWord -Force
 }
 
 # Disables Most Frequently Used Applications in Start Menu
 function Disable-FrequentApps {
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" /v "NoInstrumentation" /t REG_DWORD /d 1 /f
+    # NoInstrumentation stops Windows from tracking which apps are opened most often
+    $null = New-Item -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer' -Name 'NoInstrumentation' -Value 1 -Type DWord -Force
 }
 
 # Disables Website Access to Language List (prevents fingerprinting)
 function Disable-LanguageListAccess {
-    reg add "HKCU\Control Panel\International\User Profile" /v "HttpAcceptLanguageOptOut" /t REG_DWORD /d 1 /f
+    # Browsers can read the Accept-Language header to identify users; this blocks that
+    $null = New-Item -Path 'HKCU:\Control Panel\International\User Profile' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\Control Panel\International\User Profile' -Name 'HttpAcceptLanguageOptOut' -Value 1 -Type DWord -Force
 }
 
 # Disables Windows Error Reporting
 function Disable-ErrorReporting {
-    $keys = @(
-        "HKCU\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting",
-        "HKLM\SOFTWARE\Policies\Microsoft\PCHealth\ErrorReporting",
-        "HKLM\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting",
-        "HKLM\SOFTWARE\Policies\Microsoft\Windows\DeviceInstall\Settings",
-        "HKLM\Software\Microsoft\Windows\CurrentVersion\Component Based Servicing"
+    # Covers both user and machine policy keys to fully suppress crash reporting and error UI
+    $entries = @(
+        @{ Path = 'HKCU:\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting'; Name = 'Disabled'; Value = 1 },
+        @{ Path = 'HKLM:\SOFTWARE\Policies\Microsoft\PCHealth\ErrorReporting'; Name = 'DoReport'; Value = 0 },
+        @{ Path = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting'; Name = 'Disabled'; Value = 1 },
+        @{ Path = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting'; Name = 'DontShowUI'; Value = 1 },
+        @{ Path = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting'; Name = 'LoggingDisabled'; Value = 1 },
+        @{ Path = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Windows Error Reporting'; Name = 'DontSendAdditionalData'; Value = 1 },
+        @{ Path = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceInstall\Settings'; Name = 'DisableSendGenericDriverNotFoundToWER'; Value = 1 },
+        @{ Path = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\DeviceInstall\Settings'; Name = 'DisableSendRequestAdditionalSoftwareToWER'; Value = 1 },
+        @{ Path = 'HKLM:\Software\Microsoft\Windows\CurrentVersion\Component Based Servicing'; Name = 'DisableWerReporting'; Value = 1 }
     )
 
-    $values = @(
-        @{ Key = $keys[0]; Name = "Disabled"; Data = 1 },
-        @{ Key = $keys[1]; Name = "DoReport"; Data = 0 },
-        @{ Key = $keys[2]; Name = "Disabled"; Data = 1 },
-        @{ Key = $keys[2]; Name = "DontShowUI"; Data = 1 },
-        @{ Key = $keys[2]; Name = "LoggingDisabled"; Data = 1 },
-        @{ Key = $keys[2]; Name = "DontSendAdditionalData"; Data = 1 },
-        @{ Key = $keys[3]; Name = "DisableSendGenericDriverNotFoundToWER"; Data = 1 },
-        @{ Key = $keys[3]; Name = "DisableSendRequestAdditionalSoftwareToWER"; Data = 1 },
-        @{ Key = $keys[4]; Name = "DisableWerReporting"; Data = 1 }
-    )
-
-    foreach ($entry in $values) {
-        reg add $entry.Key /v $entry.Name /t REG_DWORD /d $entry.Data /f
+    foreach ($entry in $entries) {
+        $null = New-Item -Path $entry.Path -Force -ErrorAction SilentlyContinue
+        Set-ItemProperty -Path $entry.Path -Name $entry.Name -Value $entry.Value -Type DWord -Force
     }
 }
 
 # Configures Search Privacy
 function Set-SearchPrivacy {
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Search" /v "BingSearchEnabled" /t REG_DWORD /d 0 /f
+    # Stops the Start Menu search bar from sending queries to Bing
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Search' -Name 'BingSearchEnabled' -Value 0 -Type DWord -Force
 }
 
 function Disable-UserActivityUpload {
-    reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows\System" /v "EnableActivityFeed" /t REG_DWORD /d 0 /f
-    reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows\System" /v "PublishUserActivities" /t REG_DWORD /d 0 /f
-    reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows\System" /v "UploadUserActivities" /t REG_DWORD /d 0 /f
+    # Activity Feed tracks what you open and do; these three keys together disable collection and upload
+    $path = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\System'
+    $null = New-Item -Path $path -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path $path -Name 'EnableActivityFeed'    -Value 0 -Type DWord -Force
+    Set-ItemProperty -Path $path -Name 'PublishUserActivities' -Value 0 -Type DWord -Force
+    Set-ItemProperty -Path $path -Name 'UploadUserActivities'  -Value 0 -Type DWord -Force
 }
 
 Export-ModuleMember -Function @()

--- a/src/playbook/Executables/AtlasModules/Scripts/Modules/Qol/Qol.psm1
+++ b/src/playbook/Executables/AtlasModules/Scripts/Modules/Qol/Qol.psm1
@@ -6,9 +6,15 @@ function Set-AtlasTheme {
     Set-Theme -Path "$([Environment]::GetFolderPath('Windows'))\Resources\Themes\atlas-v0.4.x-dark.theme"
     Set-ThemeMRU
 
-    reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows\Personalization" /v "LockScreenOverlaysDisabled" /t REG_DWORD /d 1 /f
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" /v "RotatingLockScreenEnabled" /t REG_DWORD /d 0 /f
+    # Disable the Windows Spotlight overlay on the lock screen via machine policy
+    $null = New-Item -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Personalization' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Personalization' -Name 'LockScreenOverlaysDisabled' -Value 1 -Type DWord -Force
 
+    # Disable rotating lock screen images for this user
+    $null = New-Item -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\ContentDeliveryManager' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\ContentDeliveryManager' -Name 'RotatingLockScreenEnabled' -Value 0 -Type DWord -Force
+
+    # Also disable it on all LogonUI creative keys (covers per-session lock screen slots)
     foreach ($userKey in (Get-ChildItem "HKLM:SOFTWARE\Microsoft\Windows\CurrentVersion\Authentication\LogonUI\Creative").PsPath) {
         Set-ItemProperty -Path $userKey -Name 'RotatingLockScreenEnabled' -Type DWORD -Value 0 -Force
     }
@@ -16,52 +22,78 @@ function Set-AtlasTheme {
     & "$windir\AtlasModules\initPowerShell.ps1"
     Set-LockscreenImage
 
-    reg add "HKCU\Software\Policies\Microsoft\Windows\Personalization" /v "ThemeFile" /t REG_SZ /d "%windir%\Resources\Themes\atlas-v0.4.x-dark.theme" /f
+    # Store literal %windir% so Windows expands it at runtime (same behavior as reg.exe REG_SZ)
+    $null = New-Item -Path 'HKCU:\Software\Policies\Microsoft\Windows\Personalization' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\Software\Policies\Microsoft\Windows\Personalization' -Name 'ThemeFile' -Value '%windir%\Resources\Themes\atlas-v0.4.x-dark.theme' -Type String -Force
 }
 
 # Function to change the tooltip color to blue
 function Set-TooltipColorBlue {
-    reg add "HKCU\Control Panel\Colors" /v "InfoWindow" /t REG_SZ /d "246 253 255" /f
+    # InfoWindow controls the background color of tooltip popups; value is R G B as a space-separated string
+    $null = New-Item -Path 'HKCU:\Control Panel\Colors' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\Control Panel\Colors' -Name 'InfoWindow' -Value '246 253 255' -Type String -Force
 }
 
 # Function to disallow themes to change certain personalized features
 function Disable-ThemeChangesToPersonalizedFeatures {
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes" /v "ThemeChangesMousePointers" /t REG_DWORD /d 0 /f
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes" /v "ThemeChangesDesktopIcons" /t REG_DWORD /d 0 /f
+    # Prevents a theme switch from resetting the user's custom mouse pointers or desktop icons
+    $path = 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes'
+    $null = New-Item -Path $path -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path $path -Name 'ThemeChangesMousePointers' -Value 0 -Type DWord -Force
+    Set-ItemProperty -Path $path -Name 'ThemeChangesDesktopIcons' -Value 0 -Type DWord -Force
 }
 
 # Function to disable 'Always Read and Scan This Section'
 function Disable-ReadAndScan {
-    reg add "HKCU\SOFTWARE\Microsoft\Ease of Access" /v "selfscan" /t REG_DWORD /d 0 /f
-    reg add "HKCU\SOFTWARE\Microsoft\Ease of Access" /v "selfvoice" /t REG_DWORD /d 0 /f
+    # selfscan and selfvoice are Ease of Access auto-scan settings that read UI aloud; rarely useful on desktop
+    $path = 'HKCU:\SOFTWARE\Microsoft\Ease of Access'
+    $null = New-Item -Path $path -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path $path -Name 'selfscan' -Value 0 -Type DWord -Force
+    Set-ItemProperty -Path $path -Name 'selfvoice' -Value 0 -Type DWord -Force
 }
 
 # Function to disable commonly annoying features and shortcuts
 function Disable-AnnoyingFeaturesAndShortcuts {
-    reg add "HKCU\Control Panel\Accessibility\HighContrast" /v "Flags" /t REG_SZ /d "0" /f
-    reg add "HKCU\Control Panel\Accessibility\Keyboard Response" /v "Flags" /t REG_SZ /d "0" /f
-    reg add "HKCU\Control Panel\Accessibility\MouseKeys" /v "Flags" /t REG_SZ /d "0" /f
-    reg add "HKCU\Control Panel\Accessibility\StickyKeys" /v "Flags" /t REG_SZ /d "0" /f
-    reg add "HKCU\Control Panel\Accessibility\ToggleKeys" /v "Flags" /t REG_SZ /d "0" /f
+    $accessBase = 'HKCU:\Control Panel\Accessibility'
+    # Flags = '0' disables each accessibility feature; REG_SZ not DWord per Windows spec
+    foreach ($sub in @('HighContrast', 'Keyboard Response', 'MouseKeys', 'StickyKeys', 'ToggleKeys')) {
+        $null = New-Item -Path "$accessBase\$sub" -Force -ErrorAction SilentlyContinue
+        Set-ItemProperty -Path "$accessBase\$sub" -Name 'Flags' -Value '0' -Type String -Force
+    }
 
-    reg delete "HKCU\Control Panel\Input Method\Hot Keys\00000104" /f
-    reg add "HKCU\Keyboard Layout\Toggle" /v "Layout Hotkey" /t REG_SZ /d "3" /f
-    reg add "HKCU\Keyboard Layout\Toggle" /v "Language Hotkey" /t REG_SZ /d "3" /f
-    reg add "HKCU\Keyboard Layout\Toggle" /v "Hotkey" /t REG_SZ /d "3" /f
+    # Key 00000104 is the Czech/Slovak layout hot key; removing the key disables the shortcut entirely
+    Remove-Item -Path 'HKCU:\Control Panel\Input Method\Hot Keys\00000104' -Force -ErrorAction SilentlyContinue
 
-    reg add "HKCU\Software\Microsoft\Narrator\NoRoam" /v "WinEnterLaunchEnabled" /t REG_DWORD /d 0 /f
+    # Value '3' means no hotkey assigned for switching keyboard layouts or languages
+    $togglePath = 'HKCU:\Keyboard Layout\Toggle'
+    $null = New-Item -Path $togglePath -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path $togglePath -Name 'Layout Hotkey' -Value '3' -Type String -Force
+    Set-ItemProperty -Path $togglePath -Name 'Language Hotkey' -Value '3' -Type String -Force
+    Set-ItemProperty -Path $togglePath -Name 'Hotkey' -Value '3' -Type String -Force
+
+    # Stops the Win+Enter shortcut from launching Narrator
+    $null = New-Item -Path 'HKCU:\Software\Microsoft\Narrator\NoRoam' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Narrator\NoRoam' -Name 'WinEnterLaunchEnabled' -Value 0 -Type DWord -Force
 }
 
 # Function to disable the accessibility tool shortcut
 function Disable-AccessibilityToolShortcut {
-    reg add "HKCU\Control Panel\Accessibility\SlateLaunch" /v "LaunchAT" /t REG_DWORD /d 0 /f
+    # LaunchAT 0 prevents the on-screen keyboard from launching on tablet sign-in
+    $null = New-Item -Path 'HKCU:\Control Panel\Accessibility\SlateLaunch' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\Control Panel\Accessibility\SlateLaunch' -Name 'LaunchAT' -Value 0 -Type DWord -Force
 }
 
 # Function to disable Ease of Access sounds
 function Disable-EaseOfAccessSounds {
-    reg add "HKCU\Control Panel\Accessibility" /v "Warning Sounds" /t REG_DWORD /d 0 /f
-    reg add "HKCU\Control Panel\Accessibility" /v "Sound on Activation" /t REG_DWORD /d 0 /f
-    reg add "HKCU\Control Panel\Accessibility\SoundSentry" /v "WindowsEffect" /t REG_SZ /d "0" /f
+    # Stop the beeps and tones that play when accessibility features activate
+    $path = 'HKCU:\Control Panel\Accessibility'
+    $null = New-Item -Path $path -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path $path -Name 'Warning Sounds' -Value 0 -Type DWord -Force
+    Set-ItemProperty -Path $path -Name 'Sound on Activation' -Value 0 -Type DWord -Force
+
+    # WindowsEffect 0 means no visual flash substitute for system sounds
+    $null = New-Item -Path "$path\SoundSentry" -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path "$path\SoundSentry" -Name 'WindowsEffect' -Value '0' -Type String -Force
 }
 
 # Function to remove 'Extract' from context menu
@@ -73,10 +105,14 @@ function Remove-ExtractFromContextMenu {
 function Remove-PrintingFromContextMenus {
    & "$windir\AtlasDesktop\6. Advanced Configuration\Services\Printing\Disable Printing.cmd" /justcontext
 }
+
 # Function to show more details by default on file transfers
 function Show-MoreDetailsOnTransfers {
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\OperationStatusManager" /v "EnthusiastMode" /t REG_DWORD /d 1 /f
+    # EnthusiastMode 1 makes the copy/move dialog show detailed speed and time info by default
+    $null = New-Item -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\OperationStatusManager' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\OperationStatusManager' -Name 'EnthusiastMode' -Value 1 -Type DWord -Force
 }
+
 # Function to debloat Send-To context menu
 function Set-SendToContextMenu {
     & "$windir\AtlasDesktop\4. Interface Tweaks\Context Menus\Send To\Debloat Send To Context Menu.cmd" -Disable @('Documents', 'Mail Recipient', 'Fax recipient', 'Bluetooth')
@@ -84,7 +120,8 @@ function Set-SendToContextMenu {
 
 # Function to disable use of check boxes to select items
 function Disable-UseCheckBoxesToSelectItems {
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "AutoCheckSelect" /t REG_DWORD /d 0 /f
+    # AutoCheckSelect 0 removes the checkboxes that appear on hover in File Explorer
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'AutoCheckSelect' -Value 0 -Type DWord -Force
 }
 
 # Function to hide Gallery in File Explorer
@@ -94,8 +131,11 @@ function Hide-GalleryInFileExplorer {
 
 # Function to disable searching for invalid shortcuts
 function Disable-SearchingForInvalidShortcuts {
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" /v "NoResolveSearch" /t REG_DWORD /d 1 /f
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" /v "NoResolveTrack" /t REG_DWORD /d 1 /f
+    # NoResolveSearch and NoResolveTrack stop Explorer from hunting for moved files when a shortcut breaks
+    $path = 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer'
+    $null = New-Item -Path $path -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path $path -Name 'NoResolveSearch' -Value 1 -Type DWord -Force
+    Set-ItemProperty -Path $path -Name 'NoResolveTrack' -Value 1 -Type DWord -Force
 }
 
 # Function to disable network navigation pane in Explorer
@@ -105,95 +145,143 @@ function Disable-NetworkNavigationPaneInExplorer {
 
 # Function to not show Office files in Quick Access
 function Hide-OfficeFilesInQuickAccess {
-    reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer" /v "ShowCloudFilesInQuickAccess" /t REG_DWORD /d 0 /f
+    # ShowCloudFilesInQuickAccess 0 hides OneDrive and SharePoint files from the Quick Access sidebar
+    Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer' -Name 'ShowCloudFilesInQuickAccess' -Value 0 -Type DWord -Force
 }
+
 # Function to always show the full context menu on items
 function Show-FullContextMenuOnItems {
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer" /v "MultipleInvokePromptMinimum" /t REG_DWORD /d 100 /f
+    # MultipleInvokePromptMinimum controls how many files trigger the 'are you sure?' prompt; 100 means never prompt
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer' -Name 'MultipleInvokePromptMinimum' -Value 100 -Type DWord -Force
 }
 
 # Function to hide recent items in Quick Access
 function Hide-RecentItems {
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer" /v "ShowFrequent" /t REG_DWORD /d 0 /f
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer" /v "ShowRecent" /t REG_DWORD /d 0 /f
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "Start_TrackDocs" /t REG_DWORD /d 0 /f
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" /v "ClearRecentDocsOnExit" /t REG_DWORD /d 1 /f
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" /v "NoRecentDocsHistory" /t REG_DWORD /d 1 /f
-    reg add "HKCU\SOFTWARE\Policies\Microsoft\Windows\Explorer" /v "NoRemoteDestinations" /t REG_DWORD /d 1 /f
+    # Stop Explorer from tracking and showing recently opened files
+    $explorerPath = 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer'
+    Set-ItemProperty -Path $explorerPath -Name 'ShowFrequent' -Value 0 -Type DWord -Force
+    Set-ItemProperty -Path $explorerPath -Name 'ShowRecent' -Value 0 -Type DWord -Force
+    Set-ItemProperty -Path "$explorerPath\Advanced" -Name 'Start_TrackDocs' -Value 0 -Type DWord -Force
+
+    # Policy keys enforce the setting so it cannot be toggled back in Folder Options
+    $policyPath = 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer'
+    $null = New-Item -Path $policyPath -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path $policyPath -Name 'ClearRecentDocsOnExit' -Value 1 -Type DWord -Force
+    Set-ItemProperty -Path $policyPath -Name 'NoRecentDocsHistory' -Value 1 -Type DWord -Force
+
+    # NoRemoteDestinations stops apps from adding entries to the Jump List / recent files list
+    $null = New-Item -Path 'HKCU:\SOFTWARE\Policies\Microsoft\Windows\Explorer' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Policies\Microsoft\Windows\Explorer' -Name 'NoRemoteDestinations' -Value 1 -Type DWord -Force
 }
 
 # Function to minimize mouse hover time for item info
 function Set-MouseHoverTimeForItemInfo {
-    reg add "HKCU\Control Panel\Desktop" /v "MouseHoverTime" /t REG_SZ /d "20" /f
+    # MouseHoverTime is in milliseconds; 20ms means tooltips appear almost instantly
+    Set-ItemProperty -Path 'HKCU:\Control Panel\Desktop' -Name 'MouseHoverTime' -Value '20' -Type String -Force
 }
 
 # Function to configure File Explorer to open to This PC
 function Set-FileExplorerToThisPC {
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "LaunchTo" /t REG_DWORD /d 1 /f
+    # LaunchTo 1 means open to This PC; 2 would be Quick Access (Windows default)
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'LaunchTo' -Value 1 -Type DWord -Force
 }
 
 # Function to remove previous versions from Explorer
 function Remove-PreviousVersionsFromExplorer {
-    reg delete 'HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer' /v 'NoPreviousVersionsPage' /f
-    reg delete 'HKCU\SOFTWARE\Policies\Microsoft\PreviousVersions' /v 'DisableLocalPage' /f
+    # Removes the Previous Versions tab from file properties; Shadow Copy is not used on Atlas
+    Remove-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer' -Name 'NoPreviousVersionsPage' -Force -ErrorAction SilentlyContinue
+    Remove-ItemProperty -Path 'HKCU:\SOFTWARE\Policies\Microsoft\PreviousVersions' -Name 'DisableLocalPage' -Force -ErrorAction SilentlyContinue
 }
 
 # Function to remove shortcut text
 function Remove-ShortcutText {
-    reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\NamingTemplates" /v "ShortcutNameTemplate" /t REG_SZ /d ""%s.lnk"" /f
+    # ShortcutNameTemplate with "%s.lnk" keeps the original name without adding "- Shortcut" suffix
+    $null = New-Item -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\NamingTemplates' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\NamingTemplates' -Name 'ShortcutNameTemplate' -Value '"%s.lnk"' -Type String -Force
 }
 
 # Function to configure Explorer to show all files with file extensions
 function Show-AllFilesWithExtensions {
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "Hidden" /t REG_DWORD /d 1 /f
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "HideFileExt" /t REG_DWORD /d 0 /f
+    # Hidden 1 shows hidden files; HideFileExt 0 shows file extensions for all file types
+    $path = 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced'
+    Set-ItemProperty -Path $path -Name 'Hidden' -Value 1 -Type DWord -Force
+    Set-ItemProperty -Path $path -Name 'HideFileExt' -Value 0 -Type DWord -Force
 }
 
 # Function to use compact mode in File Explorer
 function Enable-CompactMode {
-    reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "UseCompactMode" /t REG_DWORD /d 1 /f
+    # UseCompactMode 1 reduces row height in File Explorer, fitting more items on screen
+    Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'UseCompactMode' -Value 1 -Type DWord -Force
 }
 
 # Function to not show Edge tabs in Alt-Tab
 function Disable-ShowEdgeTabsInAltTab {
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "MultiTaskingAltTabFilter" /t REG_DWORD /d 3 /f
+    # MultiTaskingAltTabFilter 3 means only show open windows, not browser tabs
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'MultiTaskingAltTabFilter' -Value 3 -Type DWord -Force
 }
 
 # Function to disable AutoRun
 function Disable-AutoRun {
-    reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\AutoplayHandlers" /v "DisableAutoplay" /t REG_DWORD /d 1 /f
-    reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\AutoplayHandlers\EventHandlersDefaultSelection\CameraAlternate" /v "MSTakeNoAction" /t REG_NONE /d "" /f /f 
-    reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\AutoplayHandlers\EventHandlersDefaultSelection\StorageOnArrival" /v "MSTakeNoAction" /t REG_NONE /d "" /f /f
-    reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\AutoplayHandlers\UserChosenExecuteHandlers\CameraAlternate\ShowPicturesOnArrival" /v "MSTakeNoAction" /t REG_NONE /d "" /f /f 
-    reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\AutoplayHandlers\UserChosenExecuteHandlers\StorageOnArrival" /v "MSTakeNoAction" /t REG_NONE /d "" /f /f
+    # DisableAutoplay 1 stops the AutoPlay dialog from appearing when media is inserted
+    $autoplayPath = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\AutoplayHandlers'
+    $null = New-Item -Path $autoplayPath -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path $autoplayPath -Name 'DisableAutoplay' -Value 1 -Type DWord -Force
+
+    # REG_NONE with empty data is how Windows stores 'take no action' autoplay choices
+    $camPath = "$autoplayPath\EventHandlersDefaultSelection\CameraAlternate"
+    $null = New-Item -Path $camPath -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path $camPath -Name 'MSTakeNoAction' -Value ([byte[]]@()) -Type None -Force
+
+    $storagePath = "$autoplayPath\EventHandlersDefaultSelection\StorageOnArrival"
+    $null = New-Item -Path $storagePath -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path $storagePath -Name 'MSTakeNoAction' -Value ([byte[]]@()) -Type None -Force
+
+    $camChoicePath = "$autoplayPath\UserChosenExecuteHandlers\CameraAlternate\ShowPicturesOnArrival"
+    $null = New-Item -Path $camChoicePath -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path $camChoicePath -Name 'MSTakeNoAction' -Value ([byte[]]@()) -Type None -Force
+
+    $storageChoicePath = "$autoplayPath\UserChosenExecuteHandlers\StorageOnArrival"
+    $null = New-Item -Path $storageChoicePath -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path $storageChoicePath -Name 'MSTakeNoAction' -Value ([byte[]]@()) -Type None -Force
 }
 
 # Function to disable Aero Shake
 function Disable-AeroShake {
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "DisallowShaking" /t REG_DWORD /d 1 /f
+    # DisallowShaking 1 prevents shaking a window to minimize all others
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'DisallowShaking' -Value 1 -Type DWord -Force
 }
 
 # Function to disable low disk space checks
 function Disable-LowDiskSpaceChecks {
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" /v "NoLowDiskSpaceChecks" /t REG_DWORD /d 1 /f
+    # Stops the low disk space balloon notification from appearing in the taskbar
+    $null = New-Item -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer' -Name 'NoLowDiskSpaceChecks' -Value 1 -Type DWord -Force
 }
 
 # Function to disable menu hover delay
 function Disable-MenuHoverDelay {
-    reg add "HKCU\Control Panel\Desktop" /v "MenuShowDelay" /t REG_SZ /d 0 /f
+    # MenuShowDelay is in milliseconds; 0 makes submenus open instantly on hover
+    Set-ItemProperty -Path 'HKCU:\Control Panel\Desktop' -Name 'MenuShowDelay' -Value '0' -Type String -Force
 }
 
 # Function to disable shared experiences
 function Disable-SharedExperiences {
-    reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\CDP\SettingsPage" /v "BluetoothLastDisabledNearShare" /t REG_DWORD /d 0 /f
-    reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\CDP" /v "NearShareChannelUserAuthzPolicy" /t REG_DWORD /d 0 /f
-    reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\CDP" /v "CdpSessionUserAuthzPolicy" /t REG_DWORD /d 1 /f
+    # NearShare is the Bluetooth file sharing feature; disabling it also stops CDP from running in the background
+    $null = New-Item -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\CDP\SettingsPage' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\CDP\SettingsPage' -Name 'BluetoothLastDisabledNearShare' -Value 0 -Type DWord -Force
+
+    $null = New-Item -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\CDP' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\CDP' -Name 'NearShareChannelUserAuthzPolicy' -Value 0 -Type DWord -Force
+    # CdpSessionUserAuthzPolicy 1 keeps the device discoverable but blocks actual data sharing
+    Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\CDP' -Name 'CdpSessionUserAuthzPolicy' -Value 1 -Type DWord -Force
 }
 
 # Function to disable recommendations in the Start Menu
 function Disable-StartMenuRecommendations {
-    reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "Start_IrisRecommendations" /t REG_DWORD /d 0 /f
-    reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "Start_AccountNotifications" /t REG_DWORD /d 0 /f
+    # Hides the AI-powered recommendations and account notification banners in the Start Menu
+    $path = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced'
+    Set-ItemProperty -Path $path -Name 'Start_IrisRecommendations' -Value 0 -Type DWord -Force
+    Set-ItemProperty -Path $path -Name 'Start_AccountNotifications' -Value 0 -Type DWord -Force
 }
 
 # Function to restore old context menu in Windows 11
@@ -203,88 +291,113 @@ function Restore-OldContextMenu {
 
 # Function to set unpinned control center items
 function Set-UnpinnedControlCenterItems {
+    # Explorer must be restarted for Quick Action changes to take effect
     Stop-Process -Name explorer -Force
 
-    if ((Get-WmiObject -Class Win32_OperatingSystem).Version -like "10.0.19045"){
-        # Windows 10
-        reg add "HKCU\Control Panel\Quick Actions\Control Center\Unpinned" /v "Microsoft.QuickAction.Connect" /t REG_NONE /d "" /f /f
-        reg add "HKCU\Control Panel\Quick Actions\Control Center\Unpinned" /v "Microsoft.QuickAction.Location" /t REG_NONE /d "" /f /f 
-        reg add "HKCU\Control Panel\Quick Actions\Control Center\Unpinned" /v "Microsoft.QuickAction.ScreenClipping" /t REG_NONE /d "" /f /f
-        reg add "HKCU\Control Panel\Quick Actions\Control Center\QuickActionsStateCapture" /v "Toggles" /t REG_SZ /d "Toggles,Microsoft.QuickAction.BlueLightReduction:false,Microsoft.QuickAction.AllSettings:false,Microsoft.QuickAction.Project:false" /f /f
-    }
-    else{
-        # Windows 11
-        reg add "HKCU\Control Panel\Quick Actions\Control Center\Unpinned" /v "Microsoft.QuickAction.Cast" /t REG_NONE /d "" /f /f
-        reg add "HKCU\Control Panel\Quick Actions\Control Center\Unpinned" /v "Microsoft.QuickAction.NearShare" /t REG_NONE /d "" /f /f
-        reg add "HKCU\Control Panel\Quick Actions\Control Center\QuickActionsStateCapture" /v "Toggles" /t REG_SZ /d "Toggles,Microsoft.QuickAction.BlueLightReduction:false,Microsoft.QuickAction.Accessibility:false,Microsoft.QuickAction.ProjectL2:false" /f /f
-    }
+    $unpinnedPath = 'HKCU:\Control Panel\Quick Actions\Control Center\Unpinned'
+    $capturePath  = 'HKCU:\Control Panel\Quick Actions\Control Center\QuickActionsStateCapture'
+    $null = New-Item -Path $unpinnedPath -Force -ErrorAction SilentlyContinue
+    $null = New-Item -Path $capturePath  -Force -ErrorAction SilentlyContinue
 
+    # The available Quick Actions differ between Windows 10 and 11, so we branch by OS version
+    if ((Get-CimInstance -ClassName Win32_OperatingSystem).Version -like '10.0.19045') {
+        # Windows 10: unpin Connect, Location, and Screen Clipping buttons
+        Set-ItemProperty -Path $unpinnedPath -Name 'Microsoft.QuickAction.Connect'       -Value ([byte[]]@()) -Type None -Force
+        Set-ItemProperty -Path $unpinnedPath -Name 'Microsoft.QuickAction.Location'      -Value ([byte[]]@()) -Type None -Force
+        Set-ItemProperty -Path $unpinnedPath -Name 'Microsoft.QuickAction.ScreenClipping' -Value ([byte[]]@()) -Type None -Force
+        Set-ItemProperty -Path $capturePath  -Name 'Toggles' -Value 'Toggles,Microsoft.QuickAction.BlueLightReduction:false,Microsoft.QuickAction.AllSettings:false,Microsoft.QuickAction.Project:false' -Type String -Force
+    } else {
+        # Windows 11: unpin Cast and NearShare buttons
+        Set-ItemProperty -Path $unpinnedPath -Name 'Microsoft.QuickAction.Cast'      -Value ([byte[]]@()) -Type None -Force
+        Set-ItemProperty -Path $unpinnedPath -Name 'Microsoft.QuickAction.NearShare' -Value ([byte[]]@()) -Type None -Force
+        Set-ItemProperty -Path $capturePath  -Name 'Toggles' -Value 'Toggles,Microsoft.QuickAction.BlueLightReduction:false,Microsoft.QuickAction.Accessibility:false,Microsoft.QuickAction.ProjectL2:false' -Type String -Force
+    }
 
     Start-Process -FilePath explorer.exe
 }
 
 # Function to show more pins in the Start Menu
 function Show-MorePinsInStartMenu {
-    reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "Start_Layout" /t REG_DWORD /d 1 /f
+    # Start_Layout 1 sets the Start Menu to show more pinned apps and fewer recommendations
+    Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'Start_Layout' -Value 1 -Type DWord -Force
 }
 
 # Function to decrease shutdown time
 function Set-ShutdownTime {
-    reg add "HKCU\Control Panel\Desktop" /v "HungAppTimeout" /t REG_SZ /d "2000" /f
-    reg add "HKCU\Control Panel\Desktop" /v "WaitToKillAppTimeOut" /t REG_SZ /d "2000" /f
-    reg add "HKLM\SYSTEM\CurrentControlSet\Control" /v "WaitToKillServiceTimeout" /t REG_SZ /d "2000" /f
+    # How long Windows waits before force-killing a hung app or service on shutdown (in milliseconds)
+    $desktopPath = 'HKCU:\Control Panel\Desktop'
+    Set-ItemProperty -Path $desktopPath -Name 'HungAppTimeout'      -Value '2000' -Type String -Force
+    Set-ItemProperty -Path $desktopPath -Name 'WaitToKillAppTimeOut' -Value '2000' -Type String -Force
+
+    $null = New-Item -Path 'HKLM:\SYSTEM\CurrentControlSet\Control' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control' -Name 'WaitToKillServiceTimeout' -Value '2000' -Type String -Force
 }
 
 # Function to disable startup delay
 function Disable-StartupDelay {
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Serialize" /v "StartupDelayInMSec" /t REG_DWORD /d 0 /f
+    # StartupDelayInMSec 0 removes the artificial 10-second delay Explorer adds before launching startup apps
+    $null = New-Item -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Serialize' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Serialize' -Name 'StartupDelayInMSec' -Value 0 -Type DWord -Force
 }
 
 # Function to force close applications on session end
 function Set-CloseApplicationsOnSessionEnd {
-    reg add "HKCU\Control Panel\Desktop" /v "AutoEndTasks" /t REG_SZ /d "1" /f
+    # AutoEndTasks 1 tells Windows to kill apps that do not respond to WM_QUERYENDSESSION instead of showing a dialog
+    Set-ItemProperty -Path 'HKCU:\Control Panel\Desktop' -Name 'AutoEndTasks' -Value '1' -Type String -Force
 }
 
 # Function to show Command Prompt on Win+X
 function Show-CommandPromptOnWinX {
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "DontUsePowerShellOnWinX" /t REG_DWORD /d 1 /f
+    # DontUsePowerShellOnWinX 1 replaces the PowerShell entries in Win+X with Command Prompt
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'DontUsePowerShellOnWinX' -Value 1 -Type DWord -Force
 }
 
 # Function to disable Microsoft Copilot
 function Disable-MicrosoftCopilot {
-    reg add "HKCU\Software\Policies\Microsoft\Windows\WindowsCopilot" /v "TurnOffWindowsCopilot" /t REG_DWORD /d 1 /f
+    # Policy key is required; the user-facing toggle alone does not survive updates
+    $null = New-Item -Path 'HKCU:\Software\Policies\Microsoft\Windows\WindowsCopilot' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\Software\Policies\Microsoft\Windows\WindowsCopilot' -Name 'TurnOffWindowsCopilot' -Value 1 -Type DWord -Force
 }
 
 # Function to disable Show Desktop peek on taskbar
 function Disable-ShowDesktopPeek {
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "DisablePreviewDesktop" /t REG_DWORD /d 1 /f
+    # DisablePreviewDesktop 1 disables the transparent preview when hovering over the Show Desktop button
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'DisablePreviewDesktop' -Value 1 -Type DWord -Force
 }
 
 # Function to never use tablet mode
 function Hide-TabletMode {
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\ImmersiveShell" /v "SignInMode" /t REG_DWORD /d 1 /f
+    # SignInMode 1 forces desktop mode at sign-in regardless of whether a keyboard is attached
+    $null = New-Item -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\ImmersiveShell' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\ImmersiveShell' -Name 'SignInMode' -Value 1 -Type DWord -Force
 }
 
 # Function to disable Windows Chat
 function Disable-WindowsChat {
-    reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows\Windows Chat" /v "ChatIcon" /t REG_DWORD /d 3 /f
-    reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "TaskbarMn" /t REG_DWORD /d 0 /f 
+    # ChatIcon 3 hides the Teams/Chat icon; policy key enforces it so it does not reappear after updates
+    $null = New-Item -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Windows Chat' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Windows Chat' -Name 'ChatIcon' -Value 3 -Type DWord -Force
+    Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'TaskbarMn' -Value 0 -Type DWord -Force
 }
 
 # Function to add 'End task' to the taskbar
 function Add-EndTaskToTaskbar {
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced\TaskbarDeveloperSettings" /v "TaskbarEndTask" /t REG_DWORD /d 1 /f
+    # TaskbarEndTask 1 adds a right-click 'End task' option directly on running apps in the taskbar
+    $null = New-Item -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced\TaskbarDeveloperSettings' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced\TaskbarDeveloperSettings' -Name 'TaskbarEndTask' -Value 1 -Type DWord -Force
 }
 
 # Function to disable Task View on taskbar
 function Disable-TaskViewOnTaskbar {
-    reg delete 'HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\MultiTaskingView\AllUpView' /v 'Enabled' /f
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "ShowTaskViewButton" /t REG_DWORD /d 0 /f
+    # Remove the Enabled value first; if it stays set it can override ShowTaskViewButton
+    Remove-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\MultiTaskingView\AllUpView' -Name 'Enabled' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'ShowTaskViewButton' -Value 0 -Type DWord -Force
 }
 
 # Function to set taskbar alignment to left
 function Set-TaskbarAlignLeft {
-    reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "TaskbarAl" /t REG_DWORD /d 0 /f
+    # TaskbarAl 0 moves the taskbar icons to the left; 1 is the Windows 11 centered default
+    Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced' -Name 'TaskbarAl' -Value 0 -Type DWord -Force
 }
 
 # Function to add network sharing shortcut
@@ -297,39 +410,45 @@ function Add-NetworkSharingShortcut {
 
 # Function to configure boot configuration
 function Set-BootConfiguration {
+    # Set boot menu timeout to 10 seconds and use the legacy (text-based) boot menu
     & bcdedit /timeout 10
     & bcdedit /set bootmenupolicy legacy
 }
 
 # Function to disable wallpaper compression
 function Disable-WallpaperCompression {
-    reg add "HKCU\Control Panel\Desktop" /v "JPEGImportQuality" /t REG_DWORD /d 100 /f
+    # JPEGImportQuality 100 stops Windows from re-compressing wallpapers when applying them
+    Set-ItemProperty -Path 'HKCU:\Control Panel\Desktop' -Name 'JPEGImportQuality' -Value 100 -Type DWord -Force
 }
+
 # Function to configure Start Menu
 function Set-StartMenu {
-    reg add "HKLM\SOFTWARE\Microsoft\PolicyManager\current\device\Start" /v "ConfigureStartPins" /t REG_SZ /d '{"pinnedList":[{"packagedAppId":"windows.immersivecontrolpanel_cw5n1h2txyewy!microsoft.windows.immersivecontrolpanel"},{"packagedAppId":"Microsoft.WindowsTerminal_8wekyb3d8bbwe!App"},{"desktopAppLink":"%APPDATA%\\Microsoft\\Windows\\Start Menu\\Programs\\File Explorer.lnk"},{"packagedAppId":"Microsoft.WindowsStore_8wekyb3d8bbwe!App"},{"packagedAppId":"Microsoft.GamingApp_8wekyb3d8bbwe!Microsoft.Xbox.App"},{"packagedAppId":"Microsoft.WindowsCalculator_8wekyb3d8bbwe!App"},{"packagedAppId":"Microsoft.WindowsNotepad_8wekyb3d8bbwe!App"},{"packagedAppId":"Microsoft.Paint_8wekyb3d8bbwe!App"},{"packagedAppId":"Microsoft.SecHealthUI_8wekyb3d8bbwe!SecHealthUI"}]}' /f
+    # ConfigureStartPins is a JSON payload that defines which apps are pinned in the Start Menu
+    $null = New-Item -Path 'HKLM:\SOFTWARE\Microsoft\PolicyManager\current\device\Start' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\PolicyManager\current\device\Start' -Name 'ConfigureStartPins' -Type String -Force `
+        -Value '{"pinnedList":[{"packagedAppId":"windows.immersivecontrolpanel_cw5n1h2txyewy!microsoft.windows.immersivecontrolpanel"},{"packagedAppId":"Microsoft.WindowsTerminal_8wekyb3d8bbwe!App"},{"desktopAppLink":"%APPDATA%\\Microsoft\\Windows\\Start Menu\\Programs\\File Explorer.lnk"},{"packagedAppId":"Microsoft.WindowsStore_8wekyb3d8bbwe!App"},{"packagedAppId":"Microsoft.GamingApp_8wekyb3d8bbwe!Microsoft.Xbox.App"},{"packagedAppId":"Microsoft.WindowsCalculator_8wekyb3d8bbwe!App"},{"packagedAppId":"Microsoft.WindowsNotepad_8wekyb3d8bbwe!App"},{"packagedAppId":"Microsoft.Paint_8wekyb3d8bbwe!App"},{"packagedAppId":"Microsoft.SecHealthUI_8wekyb3d8bbwe!SecHealthUI"}]}'
 
     foreach ($userKey in (Get-RegUserPaths).PsPath) {
         $default = if ($userKey -match 'AME_UserHive_Default') { $true }
         $sid = Split-Path $userKey -Leaf
-    
-        # Get Local AppData
+
+        # Get Local AppData path; default hive uses a GUID-based lookup, loaded hives use Shell Folders
         $appData = if ($default) {
             Get-UserPath -Folder 'F1B32785-6FBA-4FCF-9D55-7B8E7F157091'
         } else {
-            (Get-ItemProperty "$userKey\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders" -Name 'Local AppData' -EA 0).'Local AppData'
+            (Get-ItemProperty "$userKey\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders" -Name 'Local AppData' -ErrorAction SilentlyContinue).'Local AppData'
         }
-        
+
         Write-Title "Configuring Start Menu for '$sid'..."
         if ([string]::IsNullOrEmpty($appData) -or !(Test-Path $appData)) {
             Write-Error "Couldn't find AppData value for $sid!"
         } else {
             Write-Output "Copying default layout XML"
             Copy-Item -Path "$windir\AtlasModules\Other\Layout.xml" -Destination "$appdata\Microsoft\Windows\Shell\LayoutModification.xml" -Force
-            
+
             if (!$default) {
                 Write-Output "Clearing Start Menu pinned items"
-    
+                # Remove the binary .bin files that cache the current pinned layout; Windows recreates them on next login
                 $packages = Get-ChildItem -Path "$appdata\Packages" -Directory | Where-Object { $_.Name -match "Microsoft.Windows.StartMenuExperienceHost" }
                 foreach ($package in $packages) {
                     $bins = Get-ChildItem -Path "$appdata\Packages\$($package.Name)\LocalState" -File | Where-Object { $_.Name -like "start*.bin" }
@@ -339,29 +458,39 @@ function Set-StartMenu {
                 }
             }
         }
-        
+
         if (!$default) {
             Write-Output "Clearing default 'tilegrid'"
-            $tilegrid = Get-ChildItem -Path "$userKey\SOFTWARE\Microsoft\Windows\CurrentVersion\CloudStore\Store\Cache\DefaultAccount" -Recurse | Where-Object { $_.Name -match "start.tilegrid" }    
+            # The tilegrid cache stores the tile layout; removing it forces the Start Menu to rebuild from the XML
+            $tilegrid = Get-ChildItem -Path "$userKey\SOFTWARE\Microsoft\Windows\CurrentVersion\CloudStore\Store\Cache\DefaultAccount" -Recurse | Where-Object { $_.Name -match "start.tilegrid" }
             foreach ($key in $tilegrid) {
                 Remove-Item -Path $key.PSPath -Force
             }
         }
-    
+
         Write-Output "Removing advertisements/stubs from Start Menu (23H2+)"
-        Remove-ItemProperty -Path "$userKey\SOFTWARE\Microsoft\Windows\CurrentVersion\Start" -Name 'Config' -Force -EA 0
+        Remove-ItemProperty -Path "$userKey\SOFTWARE\Microsoft\Windows\CurrentVersion\Start" -Name 'Config' -Force -ErrorAction SilentlyContinue
     }
     Remove-AppxPackage -Package 'Microsoft.Windows.StartMenuExperienceHost*'
 
-    reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" /v "NoStartMenuMFUprogramsList" /t REG_DWORD /d 1 /f
-    reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows\Explorer" /v "ShowOrHideMostUsedApps" /t REG_DWORD /d 2 /f
-    reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows\Explorer" /v "HideRecentlyAddedApps" /t REG_DWORD /d 1 /f
-    reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows\Explorer" /v "HideRecommendedPersonalizedSites" /t REG_DWORD /d 1 /f
+    # Hide most-used apps list and recently added apps from the Start Menu via policy
+    $explorerPoliciesPath = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer'
+    $null = New-Item -Path $explorerPoliciesPath -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path $explorerPoliciesPath -Name 'NoStartMenuMFUprogramsList' -Value 1 -Type DWord -Force
+
+    $winExplorerPath = 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer'
+    $null = New-Item -Path $winExplorerPath -Force -ErrorAction SilentlyContinue
+    # ShowOrHideMostUsedApps 2 hides the most-used apps section
+    Set-ItemProperty -Path $winExplorerPath -Name 'ShowOrHideMostUsedApps'          -Value 2 -Type DWord -Force
+    Set-ItemProperty -Path $winExplorerPath -Name 'HideRecentlyAddedApps'           -Value 1 -Type DWord -Force
+    Set-ItemProperty -Path $winExplorerPath -Name 'HideRecommendedPersonalizedSites' -Value 1 -Type DWord -Force
 }
 
 # Function to configure Windows Ink Workspace
 function Set-WindowsInkWorkspace {
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\PenWorkspace" /v "PenWorkspaceAppSuggestionsEnabled" /t REG_DWORD /d 0 /f
+    # Stops the Ink Workspace from showing app suggestions (ads) on the pen menu
+    $null = New-Item -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\PenWorkspace' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\PenWorkspace' -Name 'PenWorkspaceAppSuggestionsEnabled' -Value 0 -Type DWord -Force
 }
 
 # Function to disable automatic Store app archiving
@@ -371,83 +500,129 @@ function Disable-AutomaticStoreAppArchiving {
 
 # Function to disable dynamic lighting
 function Disable-DynamicLighting {
-    reg add "HKCU\Software\Microsoft\Lighting" /v "AmbientLightingEnabled" /t REG_DWORD /d 0 /f
+    # AmbientLightingEnabled 0 stops Windows from controlling RGB lighting on supported peripherals
+    $null = New-Item -Path 'HKCU:\Software\Microsoft\Lighting' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Lighting' -Name 'AmbientLightingEnabled' -Value 0 -Type DWord -Force
 }
 
 # Function to disable mouse acceleration
 function Disable-MouseAcceleration {
-    reg add "HKCU\Control Panel\Mouse" /v "MouseSpeed" /t REG_SZ /d 0 /f
-    reg add "HKCU\Control Panel\Mouse" /v "MouseThreshold1" /t REG_SZ /d 0 /f
-    reg add "HKCU\Control Panel\Mouse" /v "MouseThreshold2" /t REG_SZ /d 0 /f
+    # MouseSpeed 0 disables pointer precision; Threshold values must also be 0 to fully remove the acceleration curve
+    $path = 'HKCU:\Control Panel\Mouse'
+    Set-ItemProperty -Path $path -Name 'MouseSpeed'      -Value '0' -Type String -Force
+    Set-ItemProperty -Path $path -Name 'MouseThreshold1' -Value '0' -Type String -Force
+    Set-ItemProperty -Path $path -Name 'MouseThreshold2' -Value '0' -Type String -Force
 }
 
 # Function to disable screen capture hotkey
 function Disable-ScreenCaptureHotkey {
-    reg add "HKCU\Control Panel\Keyboard" /v "PrintScreenKeyForSnippingEnabled" /t REG_DWORD /d 0 /f
+    # PrintScreenKeyForSnippingEnabled 0 stops Print Screen from opening Snipping Tool
+    $null = New-Item -Path 'HKCU:\Control Panel\Keyboard' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\Control Panel\Keyboard' -Name 'PrintScreenKeyForSnippingEnabled' -Value 0 -Type DWord -Force
 }
 
 # Function to disable spell checking
 function Disable-SpellChecking {
-    reg add "HKCU\SOFTWARE\Microsoft\TabletTip\1.7" /v "EnableAutocorrection" /t REG_DWORD /d 0 /f
-    reg add "HKCU\SOFTWARE\Microsoft\TabletTip\1.7" /v "EnableDoubleTapSpace" /t REG_DWORD /d 0 /f
-    reg add "HKCU\SOFTWARE\Microsoft\TabletTip\1.7" /v "EnablePredictionSpaceInsertion" /t REG_DWORD /d 0 /f
-    reg add "HKCU\SOFTWARE\Microsoft\TabletTip\1.7" /v "EnableSpellchecking" /t REG_DWORD /d 0 /f
-    reg add "HKCU\SOFTWARE\Microsoft\TabletTip\1.7" /v "EnableTextPrediction" /t REG_DWORD /d 0 /f
+    # All five values must be set to 0 to fully disable autocorrect and prediction on the touch keyboard
+    $path = 'HKCU:\SOFTWARE\Microsoft\TabletTip\1.7'
+    $null = New-Item -Path $path -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path $path -Name 'EnableAutocorrection'          -Value 0 -Type DWord -Force
+    Set-ItemProperty -Path $path -Name 'EnableDoubleTapSpace'          -Value 0 -Type DWord -Force
+    Set-ItemProperty -Path $path -Name 'EnablePredictionSpaceInsertion' -Value 0 -Type DWord -Force
+    Set-ItemProperty -Path $path -Name 'EnableSpellchecking'           -Value 0 -Type DWord -Force
+    Set-ItemProperty -Path $path -Name 'EnableTextPrediction'          -Value 0 -Type DWord -Force
 }
 
 # Function to disable unnecessary touch keyboard settings
 function Disable-UnnecessaryTouchKeyboardSettings {
-    reg add "HKCU\SOFTWARE\Microsoft\TabletTip\1.7" /v "EnableAutoShiftEngage" /t REG_DWORD /d 0 /f
-    reg add "HKCU\SOFTWARE\Microsoft\TabletTip\1.7" /v "EnableKeyAudioFeedback" /t REG_DWORD /d 0 /f
+    # EnableAutoShiftEngage auto-capitalizes after a period; EnableKeyAudioFeedback plays click sounds
+    $path = 'HKCU:\SOFTWARE\Microsoft\TabletTip\1.7'
+    $null = New-Item -Path $path -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path $path -Name 'EnableAutoShiftEngage'  -Value 0 -Type DWord -Force
+    Set-ItemProperty -Path $path -Name 'EnableKeyAudioFeedback' -Value 0 -Type DWord -Force
 }
 
 # Function to disable touch visual feedback
 function Disable-TouchVisualFeedback {
-    reg add "HKCU\Control Panel\Cursors" /v "GestureVisualization" /t REG_DWORD /d 0 /f
-    reg add "HKCU\Control Panel\Cursors" /v "ContactVisualization" /t REG_DWORD /d 0 /f
+    # Removes the visual circles that appear on screen when touching with fingers
+    $path = 'HKCU:\Control Panel\Cursors'
+    Set-ItemProperty -Path $path -Name 'GestureVisualization' -Value 0 -Type DWord -Force
+    Set-ItemProperty -Path $path -Name 'ContactVisualization' -Value 0 -Type DWord -Force
 }
 
 # Function to disable Windows Feedback
 function Disable-WindowsFeedback {
-    reg add "HKCU\SOFTWARE\Microsoft\Siuf\Rules" /v "NumberOfSIUFInPeriod" /t REG_DWORD /d 0 /f
-    reg delete 'HKCU\SOFTWARE\Microsoft\Siuf\Rules' /v 'PeriodInNanoSeconds' /f
-    reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\DataCollection" /v "DoNotShowFeedbackNotifications" /t REG_DWORD /d 1 /f
+    # NumberOfSIUFInPeriod 0 stops Windows from prompting for feedback; PeriodInNanoSeconds is removed so there is no reset window
+    $path = 'HKCU:\SOFTWARE\Microsoft\Siuf\Rules'
+    $null = New-Item -Path $path -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path $path -Name 'NumberOfSIUFInPeriod' -Value 0 -Type DWord -Force
+    Remove-ItemProperty -Path $path -Name 'PeriodInNanoSeconds' -Force -ErrorAction SilentlyContinue
+
+    # Machine policy prevents the feedback hub from being re-enabled by Windows Update
+    $null = New-Item -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\DataCollection' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\DataCollection' -Name 'DoNotShowFeedbackNotifications' -Value 1 -Type DWord -Force
 }
 
 # Function to disable Windows Spotlight
 function Disable-WindowsSpotlight {
-    reg add "HKCU\SOFTWARE\Policies\Microsoft\Windows\CloudContent" /v "DisableWindowsSpotlightFeatures" /t REG_DWORD /d 1 /f
-    reg add "HKCU\SOFTWARE\Policies\Microsoft\Windows\CloudContent" /v "DisableWindowsSpotlightWindowsWelcomeExperience" /t REG_DWORD /d 1 /f
-    reg add "HKCU\SOFTWARE\Policies\Microsoft\Windows\CloudContent" /v "DisableWindowsSpotlightOnActionCenter" /t REG_DWORD /d 1 /f
-    reg add "HKCU\SOFTWARE\Policies\Microsoft\Windows\CloudContent" /v "DisableWindowsSpotlightOnSettings" /t REG_DWORD /d 1 /f
-    reg add "HKCU\SOFTWARE\Policies\Microsoft\Windows\CloudContent" /v "DisableThirdPartySuggestions" /t REG_DWORD /d 1 /f
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons\NewStartPanelt" /v "{2cc5ca98-6485-489a-920e-b3e88a6ccce3}" /t REG_DWORD /d 1 /f
+    # Disables all Spotlight features: lock screen images, welcome experience, action center tips, and third-party suggestions
+    $path = 'HKCU:\SOFTWARE\Policies\Microsoft\Windows\CloudContent'
+    $null = New-Item -Path $path -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path $path -Name 'DisableWindowsSpotlightFeatures'                 -Value 1 -Type DWord -Force
+    Set-ItemProperty -Path $path -Name 'DisableWindowsSpotlightWindowsWelcomeExperience' -Value 1 -Type DWord -Force
+    Set-ItemProperty -Path $path -Name 'DisableWindowsSpotlightOnActionCenter'           -Value 1 -Type DWord -Force
+    Set-ItemProperty -Path $path -Name 'DisableWindowsSpotlightOnSettings'               -Value 1 -Type DWord -Force
+    Set-ItemProperty -Path $path -Name 'DisableThirdPartySuggestions'                    -Value 1 -Type DWord -Force
+
+    # Also hide the Spotlight desktop icon (the info button that appears on the wallpaper)
+    $null = New-Item -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons\NewStartPanelt' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons\NewStartPanelt' -Name '{2cc5ca98-6485-489a-920e-b3e88a6ccce3}' -Value 1 -Type DWord -Force
 }
 
 # Function to not reduce sounds while in a call
 function Disable-ReduceSoundsWhileInCall {
-    reg add "HKCU\SOFTWARE\Microsoft\Multimedia\Audio" /v "UserDuckingPreference" /t REG_DWORD /d 3 /f
+    # UserDuckingPreference 3 disables the automatic volume reduction Windows applies during calls
+    $null = New-Item -Path 'HKCU:\SOFTWARE\Microsoft\Multimedia\Audio' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Multimedia\Audio' -Name 'UserDuckingPreference' -Value 3 -Type DWord -Force
 }
 
 # Function to hide disabled and disconnected devices in sounds panel
 function Hide-DisabledAndDisconnectedDevicesInSoundsPanel {
-    reg add "HKCU\SOFTWARE\Microsoft\Multimedia\Audio\DeviceCpl" /v "ShowDisconnectedDevices" /t REG_DWORD /d 0 /f
-    reg add "HKCU\SOFTWARE\Microsoft\Multimedia\Audio\DeviceCpl" /v "ShowHiddenDevices" /t REG_DWORD /d 0 /f
+    # Cleans up the Sound control panel by hiding devices that are not actively connected
+    $path = 'HKCU:\SOFTWARE\Microsoft\Multimedia\Audio\DeviceCpl'
+    $null = New-Item -Path $path -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path $path -Name 'ShowDisconnectedDevices' -Value 0 -Type DWord -Force
+    Set-ItemProperty -Path $path -Name 'ShowHiddenDevices'       -Value 0 -Type DWord -Force
 }
 
 # Function to configure visual effects
 function Set-VisualEffects {
-    reg add "HKCU\Control Panel\Desktop" /v "FontSmoothing" /t REG_SZ /d "2" /f
-    reg add "HKCU\Control Panel\Desktop" /v "UserPreferencesMask" /t REG_BINARY /d "9012038010000000" /f
-    reg add "HKCU\Control Panel\Desktop" /v "DragFullWindows" /t REG_SZ /d "1" /f
-    reg add "HKCU\Control Panel\Desktop\WindowMetrics" /v "MinAnimate" /t REG_SZ /d "0" /f
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "ListviewAlphaSelect" /t REG_DWORD /d 1 /f
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "IconsOnly" /t REG_DWORD /d 0 /f
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "TaskbarAnimations" /t REG_DWORD /d 0 /f
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced" /v "ListviewShadow" /t REG_DWORD /d 1 /f
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects" /v "VisualFXSetting" /t REG_DWORD /d 3 /f
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\DWM" /v "EnableAeroPeek" /t REG_DWORD /d 0 /f
-    reg add "HKCU\SOFTWARE\Microsoft\Windows\DWM" /v "AlwaysHibernateThumbnails" /t REG_DWORD /d 0 /f
+    $desktopPath = 'HKCU:\Control Panel\Desktop'
+    # FontSmoothing 2 enables ClearType
+    Set-ItemProperty -Path $desktopPath -Name 'FontSmoothing'        -Value '2' -Type String -Force
+    # UserPreferencesMask is a bitmask; this value enables font smoothing and drop shadows while disabling animations
+    Set-ItemProperty -Path $desktopPath -Name 'UserPreferencesMask'  -Value ([byte[]](0x90, 0x12, 0x03, 0x80, 0x10, 0x00, 0x00, 0x00)) -Type Binary -Force
+    # DragFullWindows 1 shows window contents while dragging instead of an outline
+    Set-ItemProperty -Path $desktopPath -Name 'DragFullWindows'      -Value '1' -Type String -Force
+
+    # MinAnimate 0 disables the minimize/maximize animation for windows
+    $null = New-Item -Path "$desktopPath\WindowMetrics" -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path "$desktopPath\WindowMetrics" -Name 'MinAnimate' -Value '0' -Type String -Force
+
+    $advPath = 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced'
+    Set-ItemProperty -Path $advPath -Name 'ListviewAlphaSelect' -Value 1 -Type DWord -Force  # Translucent selection rectangle
+    Set-ItemProperty -Path $advPath -Name 'IconsOnly'           -Value 0 -Type DWord -Force  # Show thumbnails not icons
+    Set-ItemProperty -Path $advPath -Name 'TaskbarAnimations'   -Value 0 -Type DWord -Force  # Disable taskbar animations
+    Set-ItemProperty -Path $advPath -Name 'ListviewShadow'      -Value 1 -Type DWord -Force  # Drop shadow on icon labels
+
+    # VisualFXSetting 3 means custom; required so Windows respects the individual settings above
+    $null = New-Item -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects' -Name 'VisualFXSetting' -Value 3 -Type DWord -Force
+
+    # Disable Aero Peek and thumbnail hibernation from the DWM (Desktop Window Manager)
+    $null = New-Item -Path 'HKCU:\SOFTWARE\Microsoft\Windows\DWM' -Force -ErrorAction SilentlyContinue
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\DWM' -Name 'EnableAeroPeek'          -Value 0 -Type DWord -Force
+    Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\DWM' -Name 'AlwaysHibernateThumbnails' -Value 0 -Type DWord -Force
 }
 
 Export-ModuleMember -Function @()

--- a/src/playbook/Executables/AtlasModules/Scripts/Modules/Utils/Utils.psm1
+++ b/src/playbook/Executables/AtlasModules/Scripts/Modules/Utils/Utils.psm1
@@ -15,8 +15,10 @@ function Read-Pause {
         [switch]$NewLine
     )
 
-    if ($NewLine) { Write-Output "" }
-    $null = Read-Host $Message
+    process {
+        if ($NewLine) { Write-Output "" }
+        $null = Read-Host $Message
+    }
 }
 
 enum MsgIcon {
@@ -106,6 +108,7 @@ function Stop-TasksUnderRoots {
     }
     catch {
         # Module may not be available on older systems; continue with fallbacks.
+        $null = $_
     }
 
     $tasks = @()
@@ -156,6 +159,7 @@ function Stop-TasksUnderRoots {
         }
         catch {
             # Ignore and fall back to schtasks below.
+            $null = $_
         }
     }
 

--- a/src/playbook/Executables/AtlasModules/Scripts/ScriptWrappers/DisableFileSharing.ps1
+++ b/src/playbook/Executables/AtlasModules/Scripts/ScriptWrappers/DisableFileSharing.ps1
@@ -18,7 +18,7 @@ foreach ($interface in $interfaces) {
 }
 
 # Disable NetBIOS service
-sc.exe config NetBT start=disabled | Out-Null
+Set-Service -Name NetBT -StartupType Disabled
 
 # Set network profile to 'Public Network'
 Get-NetConnectionProfile | Set-NetConnectionProfile -NetworkCategory Public

--- a/src/playbook/Executables/AtlasModules/Scripts/ScriptWrappers/EnableFileSharing.ps1
+++ b/src/playbook/Executables/AtlasModules/Scripts/ScriptWrappers/EnableFileSharing.ps1
@@ -18,7 +18,7 @@ foreach ($interface in $interfaces) {
 }
 
 # Enable NetBIOS service
-sc.exe config NetBT start=system | Out-Null
+Set-Service -Name NetBT -StartupType System
 
 choice /c:yn /n /m "Would you like to change your network profile to 'Private'? [Y/N] "
 if ($LASTEXITCODE -eq 1) {
@@ -36,7 +36,7 @@ if ($LASTEXITCODE -eq 1) {
     } | Enable-NetFirewallRule
 
     # Set up network connected devices automatically
-    New-Item -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\NcdAutoSetup\Private" -Force -EA SilentlyContinue | Out-Null
+    New-Item -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\NcdAutoSetup\Private" -Force -ErrorAction SilentlyContinue | Out-Null
     Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\NcdAutoSetup\Private" -Name "AutoSetup" -Value 1 | Out-Null
 }
 

--- a/src/playbook/Executables/AtlasModules/Scripts/newUsers.ps1
+++ b/src/playbook/Executables/AtlasModules/Scripts/newUsers.ps1
@@ -71,7 +71,8 @@ if ([string]::IsNullOrWhiteSpace($browser)) {
 }
 
 & "$atlasModules\Scripts\taskbarPins.ps1" $browser
-& reg.exe add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Search" /v "SearchboxTaskbarMode" /t REG_DWORD /d 1 /f *> $null
+$null = New-Item -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Search' -Force -ErrorAction SilentlyContinue
+Set-ItemProperty -Path 'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Search' -Name 'SearchboxTaskbarMode' -Value 1 -Type DWord -Force
 
 # Leave
 Start-Sleep 5 

--- a/src/playbook/Executables/STOPFOLDERPROC.ps1
+++ b/src/playbook/Executables/STOPFOLDERPROC.ps1
@@ -50,6 +50,7 @@ function Stop-TasksUnderRoots {
     }
     catch {
         # Module may not be available on older systems; continue with fallbacks.
+        $null = $_
     }
 
     $tasks = @()
@@ -100,6 +101,7 @@ function Stop-TasksUnderRoots {
         }
         catch {
             # Ignore and fall back to schtasks below.
+            $null = $_
         }
     }
 


### PR DESCRIPTION
Replaces deprecated shell invocations with native PowerShell equivalents across the AtlasModules scripts, and adds PSScriptAnalyzer to CI.

**Changes:**
- `reg.exe add/delete` → `Set-ItemProperty` / `Remove-ItemProperty` / `Remove-Item`
- `sc.exe config start=` → `Set-Service -StartupType`
- `Get-WmiObject` → `Get-CimInstance`
- `setx` → `[Environment]::SetEnvironmentVariable`
- `schtasks /Change /Disable` → `Disable-ScheduledTask`
- `-EA` alias → `-ErrorAction`
- `Delete-UserChoiceKey` → `Remove-UserChoiceKey` (unapproved verb)
- Fixed empty catch blocks and unused variables
- Added inline comments throughout
- Added PSScriptAnalyzer lint workflow