### PR TITLE
chore: add editor build support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,6 @@
 # perform crlf normalization on batch and cmd files
+*.ps1 eol=crlf
+*.psm1 eol=crlf
 *.bat eol=crlf
 *.cmd eol=crlf
 *.sh eol=lf

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,26 @@
+{
+  "lsp": {
+    "yaml-language-server": {
+      "settings": {
+        "yaml": {
+          "customTags": [
+            "!run: mapping",
+            "!registryKey: mapping",
+            "!registryValue: mapping",
+            "!appx: mapping",
+            "!file: mapping",
+            "!service: mapping",
+            "!scheduledTask: mapping",
+            "!taskKill: mapping",
+            "!systemPackage: mapping",
+            "!cmd: mapping",
+            "!powerShell: mapping",
+            "!writeStatus: mapping",
+            "!writeStatus mapping",
+            "!task: mapping"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -1,0 +1,22 @@
+[
+  {
+    "label": "Build Playbook (Test)",
+    "command": "Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force; $repo = if (Test-Path '$ZED_WORKTREE_ROOT/src/dependencies/local-build.ps1') { '$ZED_WORKTREE_ROOT' } elseif (Test-Path '$ZED_WORKTREE_ROOT/atlas/src/dependencies/local-build.ps1') { '$ZED_WORKTREE_ROOT/atlas' } else { throw 'Could not find Atlas repo root from ZED_WORKTREE_ROOT.' }; Set-Location \"$repo/src/playbook\"; & \"$repo/src/dependencies/local-build.ps1\" -AddLiveLog -ReplaceOldPlaybook -Removals WinverRequirement, Verification",
+    "cwd": "$ZED_WORKTREE_ROOT"
+  },
+  {
+    "label": "Build Playbook (Test w/o deps)",
+    "command": "Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force; $repo = if (Test-Path '$ZED_WORKTREE_ROOT/src/dependencies/local-build.ps1') { '$ZED_WORKTREE_ROOT' } elseif (Test-Path '$ZED_WORKTREE_ROOT/atlas/src/dependencies/local-build.ps1') { '$ZED_WORKTREE_ROOT/atlas' } else { throw 'Could not find Atlas repo root from ZED_WORKTREE_ROOT.' }; Set-Location \"$repo/src/playbook\"; & \"$repo/src/dependencies/local-build.ps1\" -AddLiveLog -ReplaceOldPlaybook -Removals Dependencies, WinverRequirement, Verification",
+    "cwd": "$ZED_WORKTREE_ROOT"
+  },
+  {
+    "label": "Build Playbook (Release)",
+    "command": "Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force; $repo = if (Test-Path '$ZED_WORKTREE_ROOT/src/dependencies/local-build.ps1') { '$ZED_WORKTREE_ROOT' } elseif (Test-Path '$ZED_WORKTREE_ROOT/atlas/src/dependencies/local-build.ps1') { '$ZED_WORKTREE_ROOT/atlas' } else { throw 'Could not find Atlas repo root from ZED_WORKTREE_ROOT.' }; Set-Location \"$repo/src/playbook\"; & \"$repo/src/dependencies/local-build.ps1\" -FileName 'Atlas Release'",
+    "cwd": "$ZED_WORKTREE_ROOT"
+  },
+  {
+    "label": "Build Playbook (Release Candidate)",
+    "command": "Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force; $repo = if (Test-Path '$ZED_WORKTREE_ROOT/src/dependencies/local-build.ps1') { '$ZED_WORKTREE_ROOT' } elseif (Test-Path '$ZED_WORKTREE_ROOT/atlas/src/dependencies/local-build.ps1') { '$ZED_WORKTREE_ROOT/atlas' } else { throw 'Could not find Atlas repo root from ZED_WORKTREE_ROOT.' }; Set-Location \"$repo/src/playbook\"; & \"$repo/src/dependencies/local-build.ps1\" -FileName 'Atlas RC' -ReplaceOldPlaybook -Removals Verification",
+    "cwd": "$ZED_WORKTREE_ROOT"
+  }
+]

--- a/src/dependencies/local-build.ps1
+++ b/src/dependencies/local-build.ps1
@@ -405,9 +405,11 @@ try {
         }
     }
 
-    # update the oem version so the wizard displays the correct build tag
+    # update the oem version so Settings/winver display the correct build tag
     $oemYmlRelativePath = Join-Path -Path (Join-Path -Path 'Configuration' -ChildPath 'tweaks') -ChildPath (Join-Path -Path 'misc' -ChildPath 'config-oem-information.yml')
-    if (Test-Path -LiteralPath $oemYmlRelativePath -PathType Leaf) {
+    $oemScriptRelativePath = Join-Path -Path (Join-Path -Path (Join-Path -Path 'Executables' -ChildPath 'AtlasModules') -ChildPath 'Scripts') -ChildPath (Join-Path -Path 'Tasks' -ChildPath 'Set-OemInformation.ps1')
+    $oemVersionFiles = @($oemYmlRelativePath, $oemScriptRelativePath)
+    if ($oemVersionFiles | Where-Object { Test-Path -LiteralPath $_ -PathType Leaf }) {
         try {
             $confXml = [xml](Get-Content -Path 'playbook.conf' -Raw -Encoding UTF8)
             $playbookNode = $confXml.Playbook
@@ -418,16 +420,25 @@ try {
                     $versionLabel += ' (dev)'
                 }
 
-                $oemContent = Get-Content -Path $oemYmlRelativePath -Raw -Encoding UTF8
-                $updatedOemContent = $oemContent -replace 'AtlasVersionUndefined', $versionLabel
+                $updatedOemVersion = $false
+                foreach ($oemVersionFile in $oemVersionFiles) {
+                    if (-not (Test-Path -LiteralPath $oemVersionFile -PathType Leaf)) {
+                        continue
+                    }
 
-                if ($updatedOemContent -ne $oemContent) {
-                    $playbookTempPath = Get-PlaybookTempPath
-                    $tempOemYmlPath = Join-Path -Path $playbookTempPath -ChildPath $oemYmlRelativePath
-                    Set-ParentDirectory -Path $tempOemYmlPath
-                    Set-Content -Path $tempOemYmlPath -Value $updatedOemContent -Encoding UTF8
+                    $oemContent = Get-Content -Path $oemVersionFile -Raw -Encoding UTF8
+                    $updatedOemContent = $oemContent -replace 'AtlasVersionUndefined', $versionLabel
+
+                    if ($updatedOemContent -ne $oemContent) {
+                        $playbookTempPath = Get-PlaybookTempPath
+                        $tempOemPath = Join-Path -Path $playbookTempPath -ChildPath $oemVersionFile
+                        Set-ParentDirectory -Path $tempOemPath
+                        Set-Content -Path $tempOemPath -Value $updatedOemContent -Encoding UTF8
+                        $updatedOemVersion = $true
+                    }
                 }
-                else {
+
+                if (-not $updatedOemVersion) {
                     Write-Warning "Couldn't find OEM string 'AtlasVersionUndefined', not updating OEM version."
                 }
             }
@@ -440,7 +451,7 @@ try {
         }
     }
     else {
-        Write-Warning "Can't find '$oemYmlRelativePath', not setting OEM version."
+        Write-Warning "Can't find an OEM version file, not setting OEM version."
     }
 
     # skip local script + staged overrides so we dont pack duplicates


### PR DESCRIPTION
## Summary
- Add Zed YAML language-server tags for Atlas playbook custom YAML actions.
- Add Zed tasks for common local playbook build modes.
- Normalize PowerShell module/script line endings and teach local build version stamping to update the extracted OEM task script.

## Notes
- This is intentionally separate from the playbook refactor so editor/build support can be reviewed independently.

## Verification
- Ran `git diff --check new-update..HEAD` for this branch.