### PR TITLE
fix: replace $windir with $env:SystemRoot in Themes module

### DIFF
--- a/src/playbook/Executables/AtlasModules/Scripts/Modules/Themes/Domain/ThemeRegistry.ps1
+++ b/src/playbook/Executables/AtlasModules/Scripts/Modules/Themes/Domain/ThemeRegistry.ps1
@@ -8,6 +8,6 @@ function Set-ThemeMRU {
             "atlas-v0.5.x-light.theme",
             "dark.theme",
             "aero.theme"
-        ) | ForEach-Object { "$windir\resources\Themes\$_" }) -join ';');" -Type String -Force
+        ) | ForEach-Object { "$env:SystemRoot\resources\Themes\$_" }) -join ';');" -Type String -Force
     }
 }

--- a/src/playbook/Executables/AtlasModules/Scripts/Modules/Themes/Themes.psm1
+++ b/src/playbook/Executables/AtlasModules/Scripts/Modules/Themes/Themes.psm1
@@ -1,6 +1,5 @@
 Set-StrictMode -Version 3.0
 
-$windir = [Environment]::GetFolderPath('Windows')
 $domainRoot = Join-Path -Path $PSScriptRoot -ChildPath 'Domain'
 
 foreach ($domainModule in @(


### PR DESCRIPTION
Fixes PSScriptAnalyzer warning `PSUseDeclaredVarsMoreThanAssignments` in `Themes.psm1`. https://github.com/Atlas-OS/Atlas/actions/runs/26191839863/job/77061913812

$windir` was assigned in `Themes.psm1` but only used via outer-scope in `Domain/ThemeRegistry.ps1`. 

PSScriptAnalyzer flags it as unused since it has no direct usage in the file.

- Replace `$windir` in `ThemeRegistry.ps1` with `$env:SystemRoot` (built-in env var)

This resolves the linter error without breaking functionality. See: https://github.com/Stensel8/Atlas-patches/actions/runs/26193046913/job/77065954691

The results/outputs will be the same, but this is a more modern approach to handle this env var. Using $windir was a thing of the CMD/BAT conventions. The more modern approach is to use $env:

### Questions
- [x] Did you test your changes or double-check that they work?
- [x] Did you read and follow the [Atlas Contribution Guidelines](https://docs.atlasos.net/contributions/)?