### PR TITLE
fix: warn about WSL impact of disabling VBS

### DIFF
--- a/src/playbook/Executables/AtlasDesktop/7. Security/Core Isolation (VBS)/Disable VBS.cmd
+++ b/src/playbook/Executables/AtlasDesktop/7. Security/Core Isolation (VBS)/Disable VBS.cmd
@@ -16,6 +16,12 @@ fltmc > nul 2>&1 || (
     exit /b
 )
 
+if /i not "%~1"=="/silent" (
+    echo WARNING: Disabling VBS may prevent WSL2 and Docker Desktop from starting.
+    choice /c:yn /n /m "Continue? [Y/N] "
+    if errorlevel 2 exit /b
+)
+
 :: Update Registry (State and Path)
 reg add "HKLM\SOFTWARE\AtlasOS\Services\%settingName%" /v state /t REG_DWORD /d %stateValue% /f > nul
 reg add "HKLM\SOFTWARE\AtlasOS\Services\%settingName%" /v path /t REG_SZ /d "%scriptPath%" /f > nul

--- a/src/playbook/Executables/AtlasDesktop/7. Security/Core Isolation (VBS)/Enable VBS.cmd
+++ b/src/playbook/Executables/AtlasDesktop/7. Security/Core Isolation (VBS)/Enable VBS.cmd
@@ -2,7 +2,7 @@
 :: Change to match the setting name (e.g., Sleep, Indexing, etc.)
 set "settingName=VbsState"
 :: Change to 0 (Disabled) or 1 (Enabled/Minimal) etc
-set "stateValue=0"
+set "stateValue=1"
 set "scriptPath=%~f0"
 
 set "___args="%~f0" %*"

--- a/src/playbook/Executables/AtlasModules/Scripts/ScriptWrappers/ConfigVBS.ps1
+++ b/src/playbook/Executables/AtlasModules/Scripts/ScriptWrappers/ConfigVBS.ps1
@@ -11,7 +11,7 @@ $kernelShadowStacks = "HKLM:\SYSTEM\CurrentControlSet\Control\DeviceGuard\Scenar
 $credentialGuard = "HKLM:\SYSTEM\CurrentControlSet\Control\DeviceGuard\Scenarios\CredentialGuard"
 
 if ($DisableAllVBS) {
-	Write-Warning "Disabling VBS features..."
+	Write-Warning "Disabling VBS features. This may prevent WSL2 and Docker Desktop from starting."
 
 	# Memory Integrity
 	New-ItemProperty -Path $memIntegrity -Name "Enabled" -Value 0 -PropertyType DWORD -Force # Need to be forced since Windows 11 24H2

--- a/src/playbook/playbook.conf
+++ b/src/playbook/playbook.conf
@@ -107,7 +107,7 @@ Atlas makes your computer snappier and more private with lots of usability impro
 				<Name>disable-power-saving</Name>
 			</CheckboxOption>
 				<CheckboxOption>
-					<Text>Disable Core Isolation</Text>
+					<Text>Disable Core Isolation (may break WSL2/Docker)</Text>
 					<Name>disable-core-isolation</Name>
 				</CheckboxOption>
 			</Options>


### PR DESCRIPTION
## Summary

Warns users that disabling Core Isolation/VBS may prevent WSL2 and Docker Desktop from starting, and fixes the VBS enable-state metadata.

Related to #1615.

## Root cause and scope

The reported error occurs while HCS creates the WSL2 VM. Current Atlas sources do not modify the implicated `vmcompute`, VMBus, or storage virtualization components. Disabling VBS remains a plausible hardware-dependent trigger, but it is not proven to explain every `ERROR_PATH_NOT_FOUND` report.

This change therefore adds an evidence-backed warning and confirmation instead of introducing a speculative service, driver, optional-feature, or BCD repair.

## Changes

- Label the Core Isolation option with its possible WSL2/Docker impact.
- Show the same warning from the shared VBS PowerShell path.
- Require confirmation before using the post-install Disable VBS command.
- Record the Enable VBS state as enabled (`1`) instead of disabled (`0`).

## Validation

- Parsed `playbook.conf` successfully as XML.
- Parsed `ConfigVBS.ps1` successfully with the PowerShell parser.
- Verified the warning occurs before registry mutation and `/silent` bypass remains available.
- Verified Disable VBS records `0` and Enable VBS records `1`.
- Built the playbook successfully with `local-build.ps1`.
- Tested the generated APBX archive successfully and verified all four patched members.
- `git diff --check upstream/main...HEAD` passed.

## Testing limitation

Runtime HCS behavior requires testing on supported Windows hardware with WSL2 or Docker Desktop. This PR does not claim to repair every possible cause of the reported HCS error.
