### PR TITLE
﻿Fix 7 bugs across 5 files: HKCU propagation, uninstall warning, EKU …

### DIFF
--- a/src/playbook/Executables/APPLYDUHIVE.ps1
+++ b/src/playbook/Executables/APPLYDUHIVE.ps1
@@ -13,7 +13,7 @@ foreach ($yamlFile in $yamlFiles) {
     $parsedYaml = ConvertFrom-Yaml $yamlContent
     foreach ($entry in $parsedYaml) {
         foreach ($value in $entry.actions.path) {
-            if ($value -like 'HKCU') {
+            if ($value -like 'HKCU*') {
                 if (!$RegistryPaths.Contains($value.Substring(4))) { $RegistryPaths += $value.Substring(4) }
             }
         }

--- a/src/playbook/Executables/AtlasModules/Scripts/packageInstall.ps1
+++ b/src/playbook/Executables/AtlasModules/Scripts/packageInstall.ps1
@@ -26,7 +26,7 @@ $safeModePackageList = "$sys32\safeModePackagesToInstall.atlasmodule"
 $env:path = "$windir;$sys32;$sys32\Wbem;$sys32\WindowsPowerShell\v1.0;" + $env:path
 $errorLevel = $warningLevel = 0
 
-$arm = ((Get-CimInstance -Class Win32_ComputerSystem).SystemType -match 'ARM64') -or ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64')
+$arm = ((Get-CimInstance -Class Win32_ComputerSystem).SystemType -match 'ARM64') -or ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') -or ($env:PROCESSOR_ARCHITEW6432 -eq 'ARM64')
 $arch = if ($arm) {'arm64'} else {'amd64'}
 
 $safeModeStatus = (Get-CimInstance -Class Win32_ComputerSystem).BootupState -ne 'Normal boot'
@@ -178,8 +178,8 @@ if ($UninstallPackages) {
 		Write-Host "[WARN] '$UninstallPackages' matched no installed packages, nothing to do." -ForegroundColor Yellow
 		$script:warningLevel++
 	} else {
-		if ($notMatchedPackages.Count -gt 0) {
-			Write-Host "[WARN] Some packages not found to uninstall: $notMatchedPackages" -ForegroundColor Yellow
+		if ($notInstalledPackages.Count -gt 0) {
+			Write-Host "[WARN] Some packages not found to uninstall: $notInstalledPackages" -ForegroundColor Yellow
 			$script:warningLevel++
 		}
 
@@ -297,7 +297,7 @@ function ProcessCab($cabPath) {
 	Write-Host "[INFO] Checking certificate..."
 	try {
 		$cert = (Get-AuthenticodeSignature $cabPath).SignerCertificate
-		if ($cert.Extensions.EnhancedKeyUsages.Value -ne "1.3.6.1.4.1.311.10.3.6") {
+		if ($cert.Extensions.EnhancedKeyUsages.Value -notcontains "1.3.6.1.4.1.311.10.3.6") {
 			Write-Host "[ERROR] Cert doesn't have proper key usages, can't continue." -ForegroundColor Red
 			$script:errorLevel++
 			return $false

--- a/src/playbook/Executables/AtlasModules/Scripts/taskbarPins.ps1
+++ b/src/playbook/Executables/AtlasModules/Scripts/taskbarPins.ps1
@@ -107,11 +107,9 @@ foreach ($userKey in (Get-RegUserPaths -NoDefault).PsPath) {
 
         Write-Output "Clearing current shortcuts..."
         $taskBarAppData = "$appData\$taskBarLocation"
-        if (Test-Path $taskBarAppData -PathType Leaf) {
-            Write-Output "Deleting TaskBar file..."
-            Remove-Item -Path $taskBarAppData -Force
+        if (Test-Path $taskBarAppData) {
+            Remove-Item -Path "$taskBarAppData\*" -Force -Recurse
         }
-        Get-ChildItem $taskBarAppData | Remove-Item -Force -Recurse
 
         Write-Output "Adding new shortcuts..."
         Copy-Item -Path "$tmp\*" -Destination $taskBarAppData -Force

--- a/src/playbook/Executables/CLIENTCBS.ps1
+++ b/src/playbook/Executables/CLIENTCBS.ps1
@@ -9,7 +9,7 @@
 # Variables
 $windir = [Environment]::GetFolderPath('Windows')
 $settingsExtensions = (Get-ChildItem "$windir\SystemApps" -Recurse).FullName | Where-Object { $_ -like '*wsxpacks\Account\SettingsExtensions.json*' }
-$arm = ((Get-CimInstance -Class Win32_ComputerSystem).SystemType -match 'ARM64') -or ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64')
+$arm = ((Get-CimInstance -Class Win32_ComputerSystem).SystemType -match 'ARM64') -or ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') -or ($env:PROCESSOR_ARCHITEW6432 -eq 'ARM64')
 if ($settingsExtensions.Count -eq 0) {
     Write-Output "Settings extensions ($settingsExtensions) not found."
     Write-Output "User is likely on Windows 10, nothing to do. Exiting..."

--- a/src/playbook/Executables/SOFTWARE.ps1
+++ b/src/playbook/Executables/SOFTWARE.ps1
@@ -13,7 +13,7 @@ param (
 
 $timeouts = @("--connect-timeout", "10", "--retry", "5", "--retry-delay", "0", "--retry-all-errors")
 $msiArgs = "/qn /quiet /norestart ALLUSERS=1 REBOOT=ReallySuppress"
-$arm = ((Get-CimInstance -Class Win32_ComputerSystem).SystemType -match 'ARM64') -or ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64')
+$arm = ((Get-CimInstance -Class Win32_ComputerSystem).SystemType -match 'ARM64') -or ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') -or ($env:PROCESSOR_ARCHITEW6432 -eq 'ARM64')
 
 # Create a temporary directory
 function Remove-TempDirectory { Pop-Location; Remove-Item -Path $tempDir -Force -Recurse -EA 0 }


### PR DESCRIPTION
…validation, taskbar cleanup, ARM64 detection

TECHNICAL EXPLANATION
---------------------

1. APPLYDUHIVE.ps1:16 - HKCU default user propagation (Critical)
   - Bug: -like 'HKCU' performs exact string match
   - Fix: Changed to -like 'HKCU*' so all HKCU paths are correctly matched
   - Impact: Previously 0% of HKCU registry tweaks were inherited by new users

2. packageInstall.ps1:181-182 - Wrong variable in uninstall warning (Medium)
   - Bug: Used $notMatchedPackages (undefined at that point) instead of $notInstalledPackages (defined on line 166)
   - Fix: Changed both references to $notInstalledPackages
   - Impact: Warning about unmatched uninstall packages was silently suppressed

3. packageInstall.ps1:300 - EKU certificate validation (Medium)
   - Bug: -ne on array returns non-matching elements; certs with multiple EKUs were incorrectly rejected
   - Fix: Changed to -notcontains which correctly tests collection membership
   - Impact: Valid multi-EKU certificates no longer falsely rejected

4. taskbarPins.ps1:108-114 - Dead code and error on missing path (Low)
   - Bug: Test-Path -PathType Leaf checks if path is a FILE; TaskBar is a DIRECTORY
   - Fix: Replaced with simple Test-Path + Remove-Item wildcard
   - Impact: No more cosmetic red errors when TaskBar dir doesn't exist

5-7. packageInstall.ps1:29, SOFTWARE.ps1:16, CLIENTCBS.ps1:12 - ARM64 detection (Low)
   - Bug: 32-bit PowerShell on ARM64 sees PROCESSOR_ARCHITECTURE=x86, not ARM64
   - Fix: Added PROCESSOR_ARCHITEW6432 fallback
   - Impact: ARM64 correctly detected in WOW64 processes when CIM query fails

PLAIN ENGLISH EXPLANATION
-------------------------

1. NEW USERS WERE MISSING YOUR SETTINGS - The script that copies your personalization tweaks to new user accounts had a typo. It was looking for an exact match when it should have been looking for anything starting with 'HKCU'. This meant none of your settings were ever applied to new users. Every new person had to start from scratch. Now it works.

2. A WARNING THAT COULDN'T SPEAK - When the installer couldn't find a Windows component to remove, it was supposed to warn you. But it referenced the wrong variable name, so the warning was silently swallowed. You'd never know something failed. Now it tells you.

3. VALID CERTIFICATES WERE BEING REJECTED - The code that verifies component-removal packages checked incorrectly. If a certificate had multiple purposes listed, it would wrongly reject it even if the correct purpose was there. Now it correctly accepts valid certs.

4. TASKBAR CLEANER WAS LOOKING IN THE WRONG PLACE - When pinning browser shortcuts, the old code checked 'is this a file?' when the taskbar is actually a folder. This never worked, so it always fell through to a backup method that would throw scary red errors if the taskbar folder didn't exist. Now it just checks 'does this exist?' and cleans up properly.

5-7. ARM64 CHIP DETECTION WAS INCOMPLETE - Three places in the code try to detect ARM64 processors. On some systems where PowerShell runs in compatibility mode, the architecture wasn't being detected at all. Added a fallback check so ARM64 systems are always correctly identified.