### PR TITLE
Fix 6 bugs across 7 files: NetbiosOptions copy-paste, taskbar cleanup…

### DIFF
--- a/src/playbook/Executables/ASSOC.ps1
+++ b/src/playbook/Executables/ASSOC.ps1
@@ -201,9 +201,12 @@ if ($Hive.StartsWith("S-"))
   $fileStream.Close()
   $dataString = [Text.Encoding]::Unicode.GetString($bytesData)
   $position1 = $dataString.IndexOf($userExperienceSearch)
-  $position2 = $dataString.IndexOf("}", $position1)
-
-  $userExperience = $dataString.Substring($position1, $position2 - $position1 + 1)
+  if ($position1 -ge 0) {
+    $position2 = $dataString.IndexOf("}", $position1)
+    if ($position2 -gt $position1) {
+      $userExperience = $dataString.Substring($position1, $position2 - $position1 + 1)
+    }
+  }
 }
 
 Write-Host "Setting file associations for HKEY_USERS\$Hive..."

--- a/src/playbook/Executables/AtlasModules/Scripts/ScriptWrappers/EnableFileSharing.ps1
+++ b/src/playbook/Executables/AtlasModules/Scripts/ScriptWrappers/EnableFileSharing.ps1
@@ -11,7 +11,7 @@ Start-Process -FilePath "$networkDiscoveryConfigPath\Enable Network Discovery Se
 # Enable NetBios over TCP/IP
 $interfaces = Get-ChildItem "HKLM:\SYSTEM\CurrentControlSet\Services\NetBT\Parameters\Interfaces" -Recurse | Where-Object { $_.GetValue("NetbiosOptions") -ne $null }
 foreach ($interface in $interfaces) {
-    Set-ItemProperty -Path $interface.PSPath -Name "NetbiosOptions" -Value 2 | Out-Null
+    Set-ItemProperty -Path $interface.PSPath -Name "NetbiosOptions" -Value 0 | Out-Null
 }
 
 # Enable NetBIOS service

--- a/src/playbook/Executables/AtlasModules/Scripts/packageInstall.ps1
+++ b/src/playbook/Executables/AtlasModules/Scripts/packageInstall.ps1
@@ -303,7 +303,7 @@ function ProcessCab($cabPath) {
 			return $false
 		}
 
-		# add test cert
+		# add Atlas cert to root store
 		# isn't cleared later as it's required for the alt repair source
 		$certRegPath = "HKLM:\Software\Microsoft\SystemCertificates\ROOT\Certificates\8A334AA8052DD244A647306A76B8178FA215F344"
 		if (!(Test-Path "$certRegPath")) {

--- a/src/playbook/Executables/CLEANUP.ps1
+++ b/src/playbook/Executables/CLEANUP.ps1
@@ -101,4 +101,4 @@ else {
 # Delete all system restore points
 # This is so that users can't attempt to revert from Atlas to stock with Restore Points
 # It won't work, a full Windows reinstall is required ^
-vssadmin delete shadows /all /quiet
+vssadmin delete shadows /all /quiet 2>$null

--- a/src/playbook/Executables/LIBREWOLF.ps1
+++ b/src/playbook/Executables/LIBREWOLF.ps1
@@ -23,6 +23,7 @@ $librewolfDownload = "https://gitlab.com/api/v4/projects/$gitLabId/packages/gene
 Write-Output "Downloading the latest LibreWolf setup"
 $outputLibrewolf = "$drive\$librewolfFileName"
 curl.exe -LSs "$librewolfDownload" -o "$outputLibrewolf" $timeouts
+if (!$?) { throw "Downloading LibreWolf failed." }
 
 Write-Output "Installing LibreWolf silently"
 Start-Process -Wait -FilePath $outputLibrewolf -ArgumentList "/S"
@@ -44,6 +45,7 @@ $librewolfUpdaterDownload = (Invoke-RestMethod -Uri "$librewolfUpdaterURI").Asse
 Write-Output "Downloading the latest LibreWolf WinUpdater ZIP"
 $outputLibrewolfUpdater = "$drive\librewolf-winupdater.zip"
 curl.exe -LSs "$librewolfUpdaterDownload" -o "$outputLibrewolfUpdater" $timeouts
+if (!$?) { throw "Downloading LibreWolf WinUpdater failed." }
 
 Write-Output "Extracting Librewolf-WinUpdater"
 Expand-Archive -Path $outputLibrewolfUpdater -DestinationPath "$programs\LibreWolf\librewolf-winupdater" -Force

--- a/src/playbook/Executables/SETPATHS.ps1
+++ b/src/playbook/Executables/SETPATHS.ps1
@@ -16,7 +16,9 @@ foreach ($key in $registryKeys) {
     if ($path -notlike "$windir\AtlasDesktop\*") {
         $marker = "AtlasDesktop\"
         $index = $path.IndexOf($marker)
-        $result = $path.Substring($index + $marker.Length)
-        Set-ItemProperty -Path $key.PSPath -Name $valueName -Value "$windir\AtlasDesktop\$result"
+        if ($index -ge 0) {
+            $result = $path.Substring($index + $marker.Length)
+            Set-ItemProperty -Path $key.PSPath -Name $valueName -Value "$windir\AtlasDesktop\$result"
+        }
     }
 }

--- a/src/playbook/Executables/TASKBARPINS.ps1
+++ b/src/playbook/Executables/TASKBARPINS.ps1
@@ -96,11 +96,9 @@ foreach ($userKey in (Get-RegUserPaths -NoDefault).PsPath) {
         
         Write-Output "Clearing current shortcuts..."
         $taskBarAppData = "$appData\$taskBarLocation"
-        if (Test-Path $taskBarAppData -PathType Leaf) {
-            Write-Output "Deleting TaskBar file..."
-            Remove-Item -Path $taskBarAppData -Force
+        if (Test-Path $taskBarAppData) {
+            Remove-Item -Path "$taskBarAppData\*" -Force -Recurse
         }
-        Get-ChildItem $taskBarAppData | Remove-Item -Force -Recurse
 
         Write-Output "Adding new shortcuts..."
         Copy-Item -Path "$tmp\*" -Destination $taskBarAppData -Force


### PR DESCRIPTION
…, IndexOf guards, curl exit codes, vssadmin stderr

TECHNICAL EXPLANATION
---------------------
1. EnableFileSharing.ps1:14 - NetbiosOptions copy-paste bug (Medium)
   - Bug: Value 2 means Disable NetBIOS; copied from DisableFileSharing.ps1
   - Fix: Changed to Value 0 (Default/Enable)
   - Impact: Enabling file sharing now actually enables NetBIOS

2. TASKBARPINS.ps1:99-102 - Dead code and error on missing path (Low)
   - Bug: Test-Path -PathType Leaf checks if path is a FILE; TaskBar is a DIRECTORY
   - Fix: Replaced with simple Test-Path + Remove-Item wildcard
   - Impact: No more cosmetic red errors when TaskBar dir doesn't exist

3. SETPATHS.ps1:19-23 - IndexOf(-1) unguarded access (Medium)
   - Bug: Substring(-1 + marker.Length) produces corrupted paths when marker not found
   - Fix: Added if ( -ge 0) guard
   - Impact: No more corrupted registry values for unmatched paths

4. LIBREWOLF.ps1:26,48 - Missing curl exit code check (Medium)
   - Bug: ErrorActionPreference does not apply to native EXEs; curl failures silently ignored
   - Fix: Added if (!True) { throw } after each curl download
   - Impact: Failed downloads now correctly halt the script

5. ASSOC.ps1:204-208 - IndexOf(-1) unguarded access (Medium)
   - Bug: IndexOf with startIndex=-1 crashes on non-English Windows where search string is absent
   - Fix: Added if ( -ge 0) guard with nested bounds check
   - Impact: No more crash when Shell32.dll lacks English text

6. CLEANUP.ps1:103 - vssadmin stderr noise (Low)
   - Bug: vssadmin prints errors to stderr when no shadow copies exist
   - Fix: Added 2> to suppress stderr
   - Impact: Cleaner output for non-critical cleanup operation

7. packageInstall.ps1:306 - Misleading comment (Trivial)
   - Bug: Comment said 'add test cert' but it adds the real Atlas cert
   - Fix: Updated comment to 'add Atlas cert to root store'
   - Impact: Documentation accuracy

PLAIN ENGLISH EXPLANATION
-------------------------
1. ENABLING FILE SHARING STILL BLOCKED FILE SHARING - The script that turns on file sharing accidentally copied a line from the 'turn off' script that still blocked sharing. Like unlocking a door but leaving the deadbolt on. Now enabling actually enables everything.

2. TASKBAR CLEANER WAS LOOKING IN THE WRONG PLACE - When pinning browser shortcuts, the cleanup code checked 'is this a file?' when the taskbar is actually a folder. That check never worked, so it always fell through to code that throws scary red errors if the taskbar folder doesn't exist. Now it just checks 'does this exist?' and cleans up safely.

3. PATH CORRECTION WAS CORRUPTING PATHS - A script fixes folder paths that point to wrong locations. But if the path didn't contain the text it was looking for, it would chop off the beginning and write garbage to the registry. Now it safely skips paths it can't fix.

4. DOWNLOADS COULD SILENTLY FAIL - When downloading LibreWolf, if the internet dropped mid-download, the script wouldn't notice and would try to install a broken file. Now it checks the download worked before continuing.

5. FILE ASSOCIATION SETUP COULD CRASH - Setting which browser opens which file type reads from a system file. On non-English Windows, that file might not have the English text it was searching for, causing the whole script to crash. Now it handles missing text gracefully.

6. ERROR MESSAGE FROM DISK CLEANUP - A cleanup command printed scary red errors when there was nothing to clean up. Now it runs silently.

7. A MISLEADING NOTE - A comment in the code said 'add test cert' but it was actually adding the real security certificate. Now the note says what it actually does.