### PR TITLE
fix: ASSOC crash, ARM64 WOW64 detect, LibreWolf downloads, Core Isolation warning

### DIFF
--- a/src/playbook/Configuration/tweaks/scripts/script-core-isolation.yml
+++ b/src/playbook/Configuration/tweaks/scripts/script-core-isolation.yml
@@ -1,6 +1,6 @@
 ---
 title: Disable Core Isolation
-description: Disables Core Isolation (VBS) based on the user's options
+description: Disables Core Isolation (VBS). May break WSL2 and Docker Desktop.
 option: 'disable-core-isolation'
 actions:
   - !powerShell:

--- a/src/playbook/Executables/ASSOC.ps1
+++ b/src/playbook/Executables/ASSOC.ps1
@@ -202,10 +202,8 @@ if ($Hive.StartsWith("S-"))
   $dataString = [Text.Encoding]::Unicode.GetString($bytesData)
   $position1 = $dataString.IndexOf($userExperienceSearch)
   if ($position1 -ge 0) {
-    $position2 = $dataString.IndexOf("}", $position1)
-    if ($position2 -ge $position1) {
-      $userExperience = $dataString.Substring($position1, $position2 - $position1 + 1)
-    }
+  $position2 = $dataString.IndexOf("}", $position1)
+  $userExperience = $dataString.Substring($position1, $position2 - $position1 + 1)
   }
 }
 

--- a/src/playbook/Executables/ASSOC.ps1
+++ b/src/playbook/Executables/ASSOC.ps1
@@ -201,9 +201,12 @@ if ($Hive.StartsWith("S-"))
   $fileStream.Close()
   $dataString = [Text.Encoding]::Unicode.GetString($bytesData)
   $position1 = $dataString.IndexOf($userExperienceSearch)
-  $position2 = $dataString.IndexOf("}", $position1)
-
-  $userExperience = $dataString.Substring($position1, $position2 - $position1 + 1)
+  if ($position1 -ge 0) {
+    $position2 = $dataString.IndexOf("}", $position1)
+    if ($position2 -ge $position1) {
+      $userExperience = $dataString.Substring($position1, $position2 - $position1 + 1)
+    }
+  }
 }
 
 Write-Host "Setting file associations for HKEY_USERS\$Hive..."

--- a/src/playbook/Executables/AtlasModules/Scripts/ASSOC.ps1
+++ b/src/playbook/Executables/AtlasModules/Scripts/ASSOC.ps1
@@ -202,10 +202,8 @@ if ($Hive.StartsWith("S-"))
   $dataString = [Text.Encoding]::Unicode.GetString($bytesData)
   $position1 = $dataString.IndexOf($userExperienceSearch)
   if ($position1 -ge 0) {
-    $position2 = $dataString.IndexOf("}", $position1)
-    if ($position2 -ge $position1) {
-      $userExperience = $dataString.Substring($position1, $position2 - $position1 + 1)
-    }
+  $position2 = $dataString.IndexOf("}", $position1)
+  $userExperience = $dataString.Substring($position1, $position2 - $position1 + 1)
   }
 }
 

--- a/src/playbook/Executables/AtlasModules/Scripts/ASSOC.ps1
+++ b/src/playbook/Executables/AtlasModules/Scripts/ASSOC.ps1
@@ -201,9 +201,12 @@ if ($Hive.StartsWith("S-"))
   $fileStream.Close()
   $dataString = [Text.Encoding]::Unicode.GetString($bytesData)
   $position1 = $dataString.IndexOf($userExperienceSearch)
-  $position2 = $dataString.IndexOf("}", $position1)
-
-  $userExperience = $dataString.Substring($position1, $position2 - $position1 + 1)
+  if ($position1 -ge 0) {
+    $position2 = $dataString.IndexOf("}", $position1)
+    if ($position2 -ge $position1) {
+      $userExperience = $dataString.Substring($position1, $position2 - $position1 + 1)
+    }
+  }
 }
 
 Write-Host "Setting file associations for HKEY_USERS\$Hive..."

--- a/src/playbook/Executables/AtlasModules/Scripts/Internal/RemoveEdge.ps1
+++ b/src/playbook/Executables/AtlasModules/Scripts/Internal/RemoveEdge.ps1
@@ -194,7 +194,7 @@ function InstallEdgeChromium {
     $link = 'Undefined'
 
     if ([Environment]::Is64BitOperatingSystem) {
-        $arm = ((Get-CimInstance -Class Win32_ComputerSystem).SystemType -match 'ARM64') -or ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64')
+        $arm = ((Get-CimInstance -Class Win32_ComputerSystem).SystemType -match 'ARM64') -or ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') -or ($env:PROCESSOR_ARCHITEW6432 -eq 'ARM64')
         $archString = ('x64', 'arm64')[$arm]
     }
     else {

--- a/src/playbook/Executables/AtlasModules/Scripts/Internal/Software.ps1
+++ b/src/playbook/Executables/AtlasModules/Scripts/Internal/Software.ps1
@@ -18,7 +18,7 @@ if (-not (Test-Path -LiteralPath $initScript -PathType Leaf)) {
 
 $script:CurlTimeouts = @('--connect-timeout', '10', '--retry', '5', '--retry-delay', '0', '--retry-all-errors')
 $script:MsiArgs = '/qn /quiet /norestart ALLUSERS=1 REBOOT=ReallySuppress'
-$script:IsArm64 = ((Get-CimInstance -Class Win32_ComputerSystem).SystemType -match 'ARM64') -or ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64')
+$script:IsArm64 = ((Get-CimInstance -Class Win32_ComputerSystem).SystemType -match 'ARM64') -or ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') -or ($env:PROCESSOR_ARCHITEW6432 -eq 'ARM64')
 $script:TempDir = Join-Path -Path $env:TEMP -ChildPath ([guid]::NewGuid().ToString())
 
 function Remove-AtlasTempDirectory {

--- a/src/playbook/Executables/AtlasModules/Scripts/Modules/Scripts/Domain/ClientCbs.ps1
+++ b/src/playbook/Executables/AtlasModules/Scripts/Modules/Scripts/Domain/ClientCbs.ps1
@@ -12,7 +12,7 @@ function Update-ClientCBS {
 # Variables
 $windir = [Environment]::GetFolderPath('Windows')
 $settingsExtensions = (Get-ChildItem "$windir\SystemApps" -Recurse).FullName | Where-Object { $_ -like '*wsxpacks\Account\SettingsExtensions.json*' }
-$arm = ((Get-CimInstance -Class Win32_ComputerSystem).SystemType -match 'ARM64') -or ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64')
+$arm = ((Get-CimInstance -Class Win32_ComputerSystem).SystemType -match 'ARM64') -or ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') -or ($env:PROCESSOR_ARCHITEW6432 -eq 'ARM64')
 if (($null -eq $settingsExtensions) -or ($settingsExtensions.Count -eq 0)) {
     Write-Output "Settings extensions ($settingsExtensions) not found."
     Write-Output "User is likely on Windows 10, nothing to do. Exiting..."

--- a/src/playbook/Executables/AtlasModules/Scripts/packageInstall.ps1
+++ b/src/playbook/Executables/AtlasModules/Scripts/packageInstall.ps1
@@ -28,7 +28,7 @@ $safeModePackageList = "$sys32\safeModePackagesToInstall.atlasmodule"
 $env:path = "$windir;$sys32;$sys32\Wbem;$sys32\WindowsPowerShell\v1.0;" + $env:path
 $errorLevel = $warningLevel = 0
 
-$arm = ((Get-CimInstance -Class Win32_ComputerSystem).SystemType -match 'ARM64') -or ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64')
+$arm = ((Get-CimInstance -Class Win32_ComputerSystem).SystemType -match 'ARM64') -or ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') -or ($env:PROCESSOR_ARCHITEW6432 -eq 'ARM64')
 $arch = if ($arm) {'arm64'} else {'amd64'}
 
 $safeModeStatus = (Get-CimInstance -Class Win32_ComputerSystem).BootupState -ne 'Normal boot'

--- a/src/playbook/Executables/CLIENTCBS.ps1
+++ b/src/playbook/Executables/CLIENTCBS.ps1
@@ -9,7 +9,7 @@
 # Variables
 $windir = [Environment]::GetFolderPath('Windows')
 $settingsExtensions = (Get-ChildItem "$windir\SystemApps" -Recurse).FullName | Where-Object { $_ -like '*wsxpacks\Account\SettingsExtensions.json*' }
-$arm = ((Get-CimInstance -Class Win32_ComputerSystem).SystemType -match 'ARM64') -or ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64')
+$arm = ((Get-CimInstance -Class Win32_ComputerSystem).SystemType -match 'ARM64') -or ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') -or ($env:PROCESSOR_ARCHITEW6432 -eq 'ARM64')
 if ($settingsExtensions.Count -eq 0) {
     Write-Output "Settings extensions ($settingsExtensions) not found."
     Write-Output "User is likely on Windows 10, nothing to do. Exiting..."

--- a/src/playbook/Executables/LIBREWOLF.ps1
+++ b/src/playbook/Executables/LIBREWOLF.ps1
@@ -24,7 +24,7 @@ Write-Output "Downloading the latest LibreWolf setup"
 $outputLibrewolf = "$drive\$librewolfFileName"
 curl.exe -LSs "$librewolfDownload" -o "$outputLibrewolf" $timeouts
 if ($LASTEXITCODE -ne 0) {
-	throw "Failed to download LibreWolf setup (curl exit code $LASTEXITCODE)."
+	throw "Downloading LibreWolf failed."
 }
 
 Write-Output "Installing LibreWolf silently"
@@ -48,7 +48,7 @@ Write-Output "Downloading the latest LibreWolf WinUpdater ZIP"
 $outputLibrewolfUpdater = "$drive\librewolf-winupdater.zip"
 curl.exe -LSs "$librewolfUpdaterDownload" -o "$outputLibrewolfUpdater" $timeouts
 if ($LASTEXITCODE -ne 0) {
-	throw "Failed to download LibreWolf WinUpdater (curl exit code $LASTEXITCODE)."
+	throw "Downloading LibreWolf WinUpdater failed."
 }
 
 Write-Output "Extracting Librewolf-WinUpdater"

--- a/src/playbook/Executables/LIBREWOLF.ps1
+++ b/src/playbook/Executables/LIBREWOLF.ps1
@@ -23,6 +23,9 @@ $librewolfDownload = "https://gitlab.com/api/v4/projects/$gitLabId/packages/gene
 Write-Output "Downloading the latest LibreWolf setup"
 $outputLibrewolf = "$drive\$librewolfFileName"
 curl.exe -LSs "$librewolfDownload" -o "$outputLibrewolf" $timeouts
+if ($LASTEXITCODE -ne 0) {
+	throw "Failed to download LibreWolf setup (curl exit code $LASTEXITCODE)."
+}
 
 Write-Output "Installing LibreWolf silently"
 Start-Process -Wait -FilePath $outputLibrewolf -ArgumentList "/S"
@@ -44,6 +47,9 @@ $librewolfUpdaterDownload = (Invoke-RestMethod -Uri "$librewolfUpdaterURI").Asse
 Write-Output "Downloading the latest LibreWolf WinUpdater ZIP"
 $outputLibrewolfUpdater = "$drive\librewolf-winupdater.zip"
 curl.exe -LSs "$librewolfUpdaterDownload" -o "$outputLibrewolfUpdater" $timeouts
+if ($LASTEXITCODE -ne 0) {
+	throw "Failed to download LibreWolf WinUpdater (curl exit code $LASTEXITCODE)."
+}
 
 Write-Output "Extracting Librewolf-WinUpdater"
 Expand-Archive -Path $outputLibrewolfUpdater -DestinationPath "$programs\LibreWolf\librewolf-winupdater" -Force

--- a/src/playbook/playbook.conf
+++ b/src/playbook/playbook.conf
@@ -107,7 +107,7 @@ Atlas makes your computer snappier and more private with lots of usability impro
 				<Name>disable-power-saving</Name>
 			</CheckboxOption>
 				<CheckboxOption>
-					<Text>Disable Core Isolation</Text>
+					<Text>Disable Core Isolation (may break WSL2/Docker)</Text>
 					<Name>disable-core-isolation</Name>
 				</CheckboxOption>
 			</Options>

--- a/src/playbook/playbook.conf
+++ b/src/playbook/playbook.conf
@@ -107,7 +107,7 @@ Atlas makes your computer snappier and more private with lots of usability impro
 				<Name>disable-power-saving</Name>
 			</CheckboxOption>
 				<CheckboxOption>
-					<Text>Disable Core Isolation (may break WSL2/Docker)</Text>
+					<Text>Disable Core Isolation (breaks WSL2/Docker)</Text>
 					<Name>disable-core-isolation</Name>
 				</CheckboxOption>
 			</Options>


### PR DESCRIPTION
﻿Fixes a few small issues:
- ASSOC.ps1: skip Shell32 substring if the search string isnt found (crash on some locales)
- LIBREWOLF.ps1: check curl exit codes
- ARM64: also check PROCESSOR_ARCHITEW6432
- playbook: note that disabling Core Isolation breaks WSL2/Docker (#1615)
